### PR TITLE
Add message methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,8 @@ trying to make it as easy as possible for you to help make pyrobuf better.
 
 For the most part, Pyrobuf should be a drag-and-drop replacement for the Google
 protobuf library. There are a few differences, though. First, Pyrobuf does not
-currently implement the `MergeFrom` and `MergeFromString` methods that allow you
-to populate a message class from multiple protobuf messages. We may add these
-methods later.
+currently implement the `ListFields`, `WhichOneOf`, `HasExtension`,
+`ClearExtension` and `ByteSize` methods.
 
 Second, Pyrobuf simply assumes that the schema being used for a given message
 is the same on the send and receive ends, so changing the type of a field on

--- a/pyrobuf/__main__.py
+++ b/pyrobuf/__main__.py
@@ -80,10 +80,10 @@ def generate(fname, out, parser, templ_pxd, templ_pyx):
     msgdef = parser.parse_from_filename(fname)
 
     with open(os.path.join(out, name_pxd), 'w') as fp:
-        fp.write(templ_pxd.render(msgdef))
+        fp.write(templ_pxd.render(msgdef, version_major=sys.version_info.major))
 
     with open(os.path.join(out, name_pyx), 'w') as fp:
-        fp.write(templ_pyx.render(msgdef))
+        fp.write(templ_pyx.render(msgdef, version_major=sys.version_info.major))
 
 
 if __name__ == "__main__":

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -253,11 +253,11 @@ class Parser(object):
                     token.enum_name = token.type
                     token.type = 'enum'
 
-                elif (token.type == 'string') and token.default is not None and (len(token.default) > 1):
+                elif (token.type in ('string', 'bytes')) and token.default is not None and (len(token.default) > 1):
                     if token.default.startswith(('"', "'")) and token.default.endswith(('"', "'")):
                         token.default = token.default[1:-1]
 
-                elif (token.type not in self.scalars) and (token.type != 'string'):
+                elif (token.type not in self.scalars) and (token.type not in ('string', 'bytes')):
                     token.message_name = token.type
                     token.type = 'message'
                     token.is_nested = False

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -293,7 +293,7 @@ class Parser(object):
 
     def add_cython_info(self, message):
         for field in message.fields:
-            field.list_type = self.list_type_map.get(field.type, 'list')
+            field.list_type = self.list_type_map.get(field.type, 'TypedList')
             field.fixed_width = (field.type in ('float', 'double', 'fixed32', 'sfixed32', 'fixed64', 'sfixed64'))
             field.var_width = (field.type in ('bool', 'enum', 'int32', 'sint32', 'uint32', 'int64', 'sint64', 'uint64'))
 

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -28,12 +28,11 @@ cdef class {{ name }}:
     {%- endif %}
 
     {%- if field.modifier != 'repeated' and field.type != 'message' %}
-    cdef bint _{{ field.name}}_isDefault
-    cdef bint __{{ field.name }}_set
+    cdef bint _{{ field.name}}_isSet
     {%endif%}
 {%- endfor %}
 
-    cdef bint __is_present_in_parent
+    cdef public bint _is_present_in_parent
 
     cdef PyObject *_listener
 
@@ -41,8 +40,7 @@ cdef class {{ name }}:
 
     cpdef void Clear(self)
     cpdef void ClearField(self, field_name)
-    cpdef void CopyFrom(self, {{ name }} other_msg)
-    cpdef void MergeFrom(self, {{ name }} other_msg)
+    cpdef bytearray SerializePartialToString(self)
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size)
 

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -25,20 +25,25 @@ cdef class {{ name }}:
     cdef {{ field.c_type }} _{{ field.name }}
     {%- endif %}
 
-    {%- if field.modifier != 'repeated' and field.type != 'message'%}
+    {%- if field.modifier != 'repeated' and field.type != 'message' %}
     cdef bint _{{ field.name}}_isDefault
-    {%endif%}
-
-    {%- if field.modifier == 'required' and field.default == None %}
     cdef bint __{{ field.name }}_set
-    {%- endif %}
+    {%endif%}
 {%- endfor %}
+
+    cdef public bint _is_present_in_parent
+
+    cdef public object _listener
 
     cpdef reset(self)
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size)
 
     cdef void _protobuf_serialize(self, bytearray buf)
+
+    cpdef void _Modified(self)
+
+    cpdef void _SetListener(self, listener)
 
     {%- for message_name, message_message in message.messages.items() %}
 {{ classdef(name + message_name, message_message) }}

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -39,10 +39,11 @@ cdef class {{ name }}:
     cpdef void reset(self)
 
     cpdef void Clear(self)
-    cpdef void ClearField(self, field_name)
+    cpdef void ClearField(self, str field_name)
+    cpdef bint HasField(self, str field_name) except -1
     cpdef bint IsInitialized(self)
-    cpdef int ParseFromString(self, data, size=?, bint reset=?)
-    cpdef bytearray SerializeToString(self)
+    cpdef int MergeFromString(self, data, size=*) except -1
+    cpdef int ParseFromString(self, data, size=*, bint reset=*) except -1
     cpdef bytearray SerializePartialToString(self)
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size)

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -40,6 +40,9 @@ cdef class {{ name }}:
 
     cpdef void Clear(self)
     cpdef void ClearField(self, field_name)
+    cpdef bint IsInitialized(self)
+    cpdef int ParseFromString(self, data, size=?, bint reset=?)
+    cpdef bytearray SerializeToString(self)
     cpdef bytearray SerializePartialToString(self)
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size)

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -12,6 +12,9 @@ from {{ import }}_proto cimport *
 
 {%- macro classdef(name, message) %}
 cdef class {{ name }}:
+
+    cdef object __weakref__
+
 {% for field in message.fields|sort(attribute='index') -%}
     {%- if field.modifier == 'repeated' %}
     cdef {{ field.list_type }} _{{ field.name }}

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -1,5 +1,6 @@
 from libc.stdint cimport *
 from libc.string cimport *
+from cpython.ref cimport PyObject
 
 from pyrobuf_list cimport *
 from pyrobuf_util cimport *
@@ -12,8 +13,6 @@ from {{ import }}_proto cimport *
 
 {%- macro classdef(name, message) %}
 cdef class {{ name }}:
-
-    cdef object __weakref__
 
 {% for field in message.fields|sort(attribute='index') -%}
     {%- if field.modifier == 'repeated' %}
@@ -34,11 +33,16 @@ cdef class {{ name }}:
     {%endif%}
 {%- endfor %}
 
-    cdef public bint _is_present_in_parent
+    cdef bint __is_present_in_parent
 
-    cdef public object _listener
+    cdef PyObject *_listener
 
     cpdef reset(self)
+
+    cpdef void Clear(self)
+    cpdef void ClearField(self, field_name)
+    cpdef void CopyFrom(self, {{ name }} other_msg)
+    cpdef void MergeFrom(self, {{ name }} other_msg)
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size)
 

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -48,8 +48,6 @@ cdef class {{ name }}:
 
     cpdef void _Modified(self)
 
-    cpdef void _SetListener(self, listener)
-
     {%- for message_name, message_message in message.messages.items() %}
 {{ classdef(name + message_name, message_message) }}
     {%- endfor %}

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -39,9 +39,11 @@ cdef class {{ name }}:
     cpdef void reset(self)
 
     cpdef void Clear(self)
-    cpdef void ClearField(self, str field_name)
-    cpdef bint HasField(self, str field_name) except -1
+    cpdef void ClearField(self, field_name)
+    cpdef void CopyFrom(self, {{ name }} other_msg)
+    cpdef bint HasField(self, field_name) except -1
     cpdef bint IsInitialized(self)
+    cpdef void MergeFrom(self, {{ name }} other_msg)
     cpdef int MergeFromString(self, data, size=*) except -1
     cpdef int ParseFromString(self, data, size=*, bint reset=*) except -1
     cpdef bytearray SerializePartialToString(self)

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -36,7 +36,7 @@ cdef class {{ name }}:
 
     cdef PyObject *_listener
 
-    cpdef reset(self)
+    cpdef void reset(self)
 
     cpdef void Clear(self)
     cpdef void ClearField(self, field_name)

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -200,6 +200,9 @@ cdef class {{ name }}:
             {%- else %}
             self._{{ field.name }} = value
             {%- endif %}
+            {%- if field.type == 'message' %}
+            self._{{ field.name }}._SetListener(self)
+            {%- endif %}
         {%- endif %}
             if not self._is_present_in_parent:
                 self._Modified()
@@ -267,7 +270,7 @@ cdef class {{ name }}:
                 {%- if field.type == 'message' %}
                 {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
                 {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
-                current_offset += {{ field.name }}_elt._protobuf_deserialize(&memory[current_offset], {{ field.name }}_elt_size)
+                current_offset += {{ field.name }}_elt._protobuf_deserialize(memory+current_offset, {{ field.name }}_elt_size)
                 {%- elif field.type == 'string' %}
                 {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
                 {{ field.name }}_elt = str(memory[current_offset:current_offset + {{ field.name }}_elt_size])
@@ -287,7 +290,7 @@ cdef class {{ name }}:
 
         {%- elif field.type == 'message' %}
                 {{ field.name }}_size = get_varint64(memory, &current_offset)
-                current_offset += self._{{ field.name }}._protobuf_deserialize(&memory[current_offset], {{ field.name }}_size)
+                current_offset += self._{{ field.name }}._protobuf_deserialize(memory+current_offset, {{ field.name }}_size)
 
         {%- elif field.type == 'string' %}
                 {{ field.name }}_size = get_varint64(memory, &current_offset)
@@ -338,10 +341,12 @@ cdef class {{ name }}:
                 {%- elif field.type == 'string' %}
             self._{{ field.name }} = TypedList(str, self)
                 {%- else %}
-            self._{{ field.name }} = {{ field.list_type }}(message_listener=self)
+            self._{{ field.name }} = {{ field.list_type }}.__new__({{ field.list_type }}, message_listener=self)
                 {%- endif %}
             {%- elif field.type == 'message' %}
-            self._{{ field.name }} = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
+            self._{{ field.name }} = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}.__new__({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }})
+            self._{{ field.name }}.reset()
+            self._{{ field.name }}._SetListener(self)
             {%- elif field.default != None %}
                 {%- if field.type == 'string' %}
             self._{{ field.name }} = "{{ field.default }}"
@@ -359,7 +364,8 @@ cdef class {{ name }}:
             {%- endif %}
     {%- endfor %}
 
-        self._Modified()
+        if not self._is_present_in_parent:
+            self._Modified()
 
     def CopyFrom(self, other_msg):
         """
@@ -507,8 +513,6 @@ cdef class {{ name }}:
         if not already_present_in_parent:
             self._Modified()
 
-        {{ find_initialization_errors(message) }}
-
         return buf
 
     @classmethod
@@ -526,7 +530,7 @@ cdef class {{ name }}:
         cdef int length
     {%- endif %}
 
-    {% for field in message.fields|sort(attribute='index') %}
+    {%- for field in message.fields|sort(attribute='index') %}
 
         # {{ field.name }}
         {%- if field.modifier == 'repeated' %}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -1,4 +1,3 @@
-from libc.stdio cimport printf
 from libc.stdint cimport *
 from libc.string cimport *
 from cpython.ref cimport PyObject

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -18,7 +18,14 @@ from {{ import }}_proto cimport *
 {%- endmacro %}
 
 {%- macro find_initialization_errors(message) %}
-    {%- for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+    {%- if message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
+        cdef int i
+    {%- endif %}
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_msg
+    {%- endfor %}
+
+    {% for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
         {%- if field.type == 'message' %}
         if not self._{{ field.name }}.IsInitialized():
         {%- else %}
@@ -33,7 +40,8 @@ from {{ import }}_proto cimport *
     {%- endfor %}
 
     {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
-        for i, {{ field.name }}_msg in enumerate(self._{{ field.name }}):
+        for i in len(self._{{ field.name }}):
+            {{ field.name }}_msg = <{% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}>self._{{ field.name }}[i]
             if not {{ field.name }}_msg.IsInitialized():
                 raise Exception("Message {{ name }} is missing required field: {{ field.name }}[%d]" % i)
     {%- endfor %}
@@ -396,7 +404,7 @@ cdef class {{ name }}:
     {%- endfor %}
         raise ValueError('Protocol message has no singular "%s" field.' % field_name)
 
-    def IsInitialized(self):
+    cpdef bint IsInitialized(self):
         """
         Checks if the message is initialized.
 
@@ -404,7 +412,14 @@ cdef class {{ name }}:
             bool: True if the message is initialized (i.e. all of its required
                 fields are set).
         """
-    {%- for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+    {%- if message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
+        cdef int i
+    {%- endif %}
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_msg
+    {%- endfor %}
+
+    {% for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
         {%- if field.type == 'message' %}
         if not self._{{ field.name }}.IsInitialized():
         {%- else %}
@@ -419,7 +434,8 @@ cdef class {{ name }}:
     {%- endfor %}
 
     {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
-        for {{ field.name }}_msg in self._{{ field.name }}:
+        for i in range(len(self._{{ field.name }})):
+            {{ field.name }}_msg = <{% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}>self._{{ field.name }}[i]
             if not {{ field.name }}_msg.IsInitialized():
                 return False
     {%- endfor %}
@@ -485,7 +501,7 @@ cdef class {{ name }}:
 
         return buf
 
-    def ParseFromString(self, data, size=None, reset=True):
+    cpdef int ParseFromString(self, data, size=None, bint reset=True):
         """
         Populate the message class from a string of protobuf encoded binary data.
 
@@ -497,7 +513,14 @@ cdef class {{ name }}:
         Returns:
             int: the number of bytes processed during serialization
         """
-        already_present_in_parent = self._is_present_in_parent
+        cdef int buf
+        cdef bint already_present_in_parent = self._is_present_in_parent
+    {%- if message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
+        cdef int i
+    {%- endif %}
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_msg
+    {%- endfor %}
 
         if size is None:
             size = len(data)
@@ -512,6 +535,27 @@ cdef class {{ name }}:
 
         if not already_present_in_parent:
             self._Modified()
+
+     {% for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+        {%- if field.type == 'message' %}
+        if not self._{{ field.name }}.IsInitialized():
+        {%- else %}
+        if not self._{{ field.name }}_isSet:
+        {%- endif %}
+            raise Exception("required field '{{ field.name }}' not initialized and does not have default")
+    {%- endfor %}
+
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'optional')|sort(attribute='index') %}
+        if self._{{ field.name }}._is_present_in_parent and not self._{{ field.name }}.IsInitialized():
+            raise Exception("Message {{ name }} is missing required field: {{ field.name }}")
+    {%- endfor %}
+
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        for i in range(len(self._{{ field.name }})):
+            {{ field.name }}_msg = <{% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}>self._{{ field.name }}[i]
+            if not {{ field.name }}_msg.IsInitialized():
+                raise Exception("Message {{ name }} is missing required field: {{ field.name }}[%d]" % i)
+    {%- endfor %}
 
         return buf
 
@@ -641,16 +685,42 @@ cdef class {{ name }}:
             self._is_present_in_parent = True
             (<object> self._listener)._Modified()
 
-    def SerializeToString(self):
+    cpdef bytearray SerializeToString(self):
         """
         Serialize the message class into a bytearray of protobuf encoded binary data.
 
         Returns:
             bytearray: a bytearray of binary data
         """
-        {{ find_initialization_errors(message) }}
+    {%- if message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
+        cdef int i
+    {%- endif %}
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_msg
+    {%- endfor %}
 
-        buf = bytearray()
+    {% for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+        {%- if field.type == 'message' %}
+        if not self._{{ field.name }}.IsInitialized():
+        {%- else %}
+        if not self._{{ field.name }}_isSet:
+        {%- endif %}
+            raise Exception("required field '{{ field.name }}' not initialized and does not have default")
+    {%- endfor %}
+
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'optional')|sort(attribute='index') %}
+        if self._{{ field.name }}._is_present_in_parent and not self._{{ field.name }}.IsInitialized():
+            raise Exception("Message {{ name }} is missing required field: {{ field.name }}")
+    {%- endfor %}
+
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        for i in range(len(self._{{ field.name }})):
+            {{ field.name }}_msg = <{% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}>self._{{ field.name }}[i]
+            if not {{ field.name }}_msg.IsInitialized():
+                raise Exception("Message {{ name }} is missing required field: {{ field.name }}[%d]" % i)
+    {%- endfor %}
+
+        cdef bytearray buf = bytearray()
         self._protobuf_serialize(buf)
         return buf
 
@@ -661,7 +731,7 @@ cdef class {{ name }}:
         Returns:
             bytearray: a bytearray of binary data
         """
-        buf = bytearray()
+        cdef bytearray buf = bytearray()
         self._protobuf_serialize(buf)
         return buf
 

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -550,7 +550,7 @@ cdef class {{ name }}:
     @classmethod
     def FromString(cls, s):
         message = cls()
-        message.ParseFromString(s)
+        message.MergeFromString(s)
         return message
 
     cdef void _protobuf_serialize(self, bytearray buf):

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -189,28 +189,28 @@ cdef class {{ name }}:
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size):
         cdef int current_offset = 0
-        cdef int key
-        cdef int field_idx
+        cdef int64_t key
+        cdef int64_t field_idx
+    {%- if message.fields|selectattr('type', 'equalto', 'message')|first is defined or
+           message.fields|selectattr('type', 'equalto', 'string')|first is defined %}
+        cdef int64_t field_size
+    {%- endif %}
         # cdef int wire_type
 
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if field.modifier == 'repeated' and field.packed|default(false) == true %}
         cdef int {{ field.name }}_marker
+        {%- endif %}
+        {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
-        cdef int {{ field.name }}_elt_size
         cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_elt
             {%- elif field.type == 'string' %}
-        cdef int {{ field.name }}_elt_size
         cdef str {{ field.name }}_elt
             {%- elif field.type == 'enum' %}
         cdef int32_t {{ field.name }}_elt
             {%- else  %}
         cdef {{ field.c_type }} {{ field.name }}_elt
             {%- endif %}
-        {%- elif field.type == 'message' %}
-        cdef int {{ field.name }}_size
-        {%- elif field.type == 'string' %}
-        cdef int {{ field.name }}_size
         {%- endif %}
     {%- endfor %}
 
@@ -248,12 +248,12 @@ cdef class {{ name }}:
             {%- else %}
                 {%- if field.type == 'message' %}
                 {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
-                {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
-                current_offset += {{ field.name }}_elt._protobuf_deserialize(memory+current_offset, {{ field.name }}_elt_size)
+                field_size = get_varint64(memory, &current_offset)
+                current_offset += {{ field.name }}_elt._protobuf_deserialize(memory+current_offset, field_size)
                 {%- elif field.type == 'string' %}
-                {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
-                {{ field.name }}_elt = str(memory[current_offset:current_offset + {{ field.name }}_elt_size])
-                current_offset += {{ field.name }}_elt_size
+                field_size = get_varint64(memory, &current_offset)
+                {{ field.name }}_elt = str(memory[current_offset:current_offset + field_size])
+                current_offset += field_size
                 {%- elif field.fixed_width == true %}
                 {{ field.name }}_elt = (<{{ field.c_type }} *>&memory[current_offset])[0]
                 current_offset += sizeof({{ field.c_type }})
@@ -268,13 +268,13 @@ cdef class {{ name }}:
             {%- endif %}
 
         {%- elif field.type == 'message' %}
-                {{ field.name }}_size = get_varint64(memory, &current_offset)
-                current_offset += self._{{ field.name }}._protobuf_deserialize(memory+current_offset, {{ field.name }}_size)
+                field_size = get_varint64(memory, &current_offset)
+                current_offset += self._{{ field.name }}._protobuf_deserialize(memory+current_offset, field_size)
 
         {%- elif field.type == 'string' %}
-                {{ field.name }}_size = get_varint64(memory, &current_offset)
-                self._{{ field.name }} = str(memory[current_offset:current_offset + {{ field.name }}_size])
-                current_offset += {{ field.name }}_size
+                field_size = get_varint64(memory, &current_offset)
+                self._{{ field.name }} = str(memory[current_offset:current_offset + field_size])
+                current_offset += field_size
 
         {%- elif field.type == 'enum' %}
                 self.{{ field.name }} = {{ field.getter }}(memory, &current_offset)
@@ -301,7 +301,7 @@ cdef class {{ name }}:
         if not self._is_present_in_parent:
             self._Modified()
 
-    cpdef void ClearField(self, field_name):
+    cpdef void ClearField(self, str field_name):
         """Clears the contents of a given field."""
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if loop.index == 1 %}
@@ -358,7 +358,7 @@ cdef class {{ name }}:
         self.reset()
         self.MergeFrom(other_msg)
 
-    def HasField(self, field_name):
+    cpdef bint HasField(self, str field_name) except -1:
         """
         Checks if a certain field is set for the message.
 
@@ -446,7 +446,7 @@ cdef class {{ name }}:
         if not self._is_present_in_parent:
             self._Modified()
 
-    def MergeFromString(self, data, size=None):
+    cpdef int MergeFromString(self, data, size=None) except -1:
         """
         Merges serialized protocol buffer data into this message.
 
@@ -457,7 +457,8 @@ cdef class {{ name }}:
         Returns:
             int: the number of bytes processed during serialization
         """
-        already_present_in_parent = self._is_present_in_parent
+        cdef int buf
+        cdef bint already_present_in_parent = self._is_present_in_parent
 
         if size is None:
             size = len(data)
@@ -472,7 +473,7 @@ cdef class {{ name }}:
 
         return buf
 
-    cpdef int ParseFromString(self, data, size=None, bint reset=True):
+    cpdef int ParseFromString(self, data, size=None, bint reset=True) except -1:
         """
         Populate the message class from a string of protobuf encoded binary data.
 
@@ -507,7 +508,7 @@ cdef class {{ name }}:
         if not already_present_in_parent:
             self._Modified()
 
-     {% for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+    {% for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
         {%- if field.type == 'message' %}
         if not self._{{ field.name }}.IsInitialized():
         {%- else %}
@@ -533,7 +534,7 @@ cdef class {{ name }}:
     @classmethod
     def FromString(cls, s):
         message = cls()
-        message.ParseFromString(s, reset=False)
+        message.ParseFromString(s)
         return message
 
     cdef void _protobuf_serialize(self, bytearray buf):
@@ -656,7 +657,7 @@ cdef class {{ name }}:
             self._is_present_in_parent = True
             (<object> self._listener)._Modified()
 
-    cpdef bytearray SerializeToString(self):
+    def SerializeToString(self):
         """
         Serialize the message class into a bytearray of protobuf encoded binary data.
 

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -1,3 +1,4 @@
+from libc.stdio cimport printf
 from libc.stdint cimport *
 from libc.string cimport *
 from cpython.ref cimport PyObject
@@ -17,6 +18,28 @@ from {{ import }}_proto cimport *
     {%- endfor %}
 {%- endmacro %}
 
+{%- macro find_initialization_errors(message) %}
+    {%- for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+        {%- if field.type == 'message' %}
+        if not self._{{ field.name }}.IsInitialized():
+        {%- else %}
+        if not self._{{ field.name }}_isSet:
+        {%- endif %}
+            raise Exception("required field '{{ field.name }}' not initialized and does not have default")
+    {%- endfor %}
+
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'optional')|sort(attribute='index') %}
+        if self._{{ field.name }}._is_present_in_parent and not self._{{ field.name }}.IsInitialized():
+            raise Exception("Message {{ name }} is missing required field: {{ field.name }}")
+    {%- endfor %}
+
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        for i, {{ field.name }}_msg in enumerate(self._{{ field.name }}):
+            if not {{ field.name }}_msg.IsInitialized():
+                raise Exception("Message {{ name }} is missing required field: {{ field.name }}[%d]" % i)
+    {%- endfor %}
+{%- endmacro %}
+
 {%- macro classdef(name, message) %}
 cdef class {{ name }}:
 
@@ -24,7 +47,7 @@ cdef class {{ name }}:
         self._listener = <PyObject *>null_listener
 
     {% if (message.fields|selectattr('type', 'equalto', 'message')|first is defined or
-           message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined) %}
+           message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined) -%}
     def __dealloc__(self):
         # Remove any references to self from child messages or repeated fields
     {%- for field in message.fields %}
@@ -35,8 +58,28 @@ cdef class {{ name }}:
     {%- endfor %}
     {%- endif %}
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.reset()
+        for field_name, field_value in kwargs.{%- if version_major == 2 -%} iter {%- endif -%} items():
+            try:
+            {%- if message.fields|selectattr('type', 'equalto', 'message')|rejectattr('modifier', 'equalto', 'repeated')|first is defined %}
+                if field_name in ('{{ message.fields|selectattr('type', 'equalto', 'message')|rejectattr('modifier', 'equalto', 'repeated')|join("','", attribute='name') }}',):
+                    getattr(self, field_name).MergeFrom(field_value)
+            {%- endif %}
+            {%- if message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
+                {% if message.fields|selectattr('type', 'equalto', 'message')|rejectattr('modifier', 'equalto', 'repeated')|first is defined -%}el{%- endif -%}
+                if field_name in ('{{ message.fields|selectattr('modifier', 'equalto', 'repeated')|join("','", attribute='name') }}',):
+                    getattr(self, field_name).extend(field_value)
+            {%- endif %}
+            {%- if (message.fields|selectattr('type', 'equalto', 'message')|first is defined or
+                    message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined) %}
+                else:
+                    setattr(self, field_name, field_value)
+            {%- else %}
+                setattr(self, field_name, field_value)
+            {%- endif %}
+            except AttributeError:
+                raise ValueError('Protocol message has no "%s" field.' % (field_name,))
         return
 
     def __str__(self):
@@ -62,7 +105,7 @@ cdef class {{ name }}:
         # reset values and populate defaults
     {% for field in message.fields %}
         {%- if field.type != 'message' and field.modifier != 'repeated' %}
-        self._{{ field.name }}_isDefault = True
+        self._{{ field.name }}_isSet = False
         {%- else %}
         if self._{{ field.name }} is not None:
             self._{{ field.name }}._SetListener(None)
@@ -93,9 +136,6 @@ cdef class {{ name }}:
         {%- else %}
         self._{{ field.name }} = 0
         {%- endif %}
-        {%- if field.modifier != 'repeated' and field.type != 'message' %}
-        self.__{{ field.name }}_set = 0
-        {%- endif %}
     {%- endfor %}
         return
 
@@ -106,7 +146,7 @@ cdef class {{ name }}:
 
         def __set__(self, value):
         {%- if field.type != 'message' and field.modifier != 'repeated' %}
-            self._{{ field.name }}_isDefault = False
+            self._{{ field.name }}_isSet = True
         {%- else %}
             if self._{{ field.name }} is not None:
                 self._{{ field.name }}._SetListener(None)
@@ -160,25 +200,18 @@ cdef class {{ name }}:
             self._{{ field.name }} = value
             {%- endif %}
         {%- endif %}
-        {%- if field.modifier != 'repeated' and field.type != 'message' %}
-            self.__{{ field.name }}_set = 1
-        {%- endif %}
-            if not self.__is_present_in_parent:
+            if not self._is_present_in_parent:
                 self._Modified()
     {% endfor %}
-
-    property _is_present_in_parent:
-        def __get__(self):
-            return self.__is_present_in_parent
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size):
         cdef int current_offset = 0
         cdef int key
         cdef int field_idx
-        cdef int wire_type
+        # cdef int wire_type
 
     {%- for field in message.fields|sort(attribute='index') %}
-        {%- if field.modifier == 'repeated' %}
+        {%- if field.modifier == 'repeated' and field.packed|default(false) == true %}
         cdef int {{ field.name }}_marker
             {%- if field.type == 'message' %}
         cdef int {{ field.name }}_elt_size
@@ -198,11 +231,11 @@ cdef class {{ name }}:
         {%- endif %}
     {%- endfor %}
 
-    {%- if message.fields|count > 0 %}
+    {% if message.fields|count > 0 %}
         while current_offset < size:
             key = get_varint64(memory, &current_offset)
             field_idx = (key >> 3)
-            wire_type = (key & 0x7)
+            # wire_type = (key & 0x7)
 
     {%- for field in message.fields|sort(attribute='index') %}
             # {{ field.name }}
@@ -213,33 +246,43 @@ cdef class {{ name }}:
         {%- endif %}
 
         {%- if field.modifier != 'repeated' and field.type != 'message' and field.type != 'enum' %}
-                self._{{field.name}}_isDefault = False
-        {% endif -%}
+                self._{{field.name}}_isSet = True
+        {%- endif %}
 
         {%- if field.modifier == 'repeated' %}
             {%- if field.packed|default(false) == true %}
                 {{ field.name }}_marker = get_varint64(memory, &current_offset)
                 {{ field.name }}_marker += current_offset
-            {%- else %}
-                {{ field.name }}_marker = 1 + current_offset
-            {%- endif %}
 
                 while current_offset < {{ field.name }}_marker:
-            {%- if field.type == 'message' %}
-                    {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
-                    {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
-                    current_offset += {{ field.name }}_elt._protobuf_deserialize(&memory[current_offset], {{ field.name }}_elt_size)
-            {%- elif field.type == 'string' %}
-                    {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
-                    {{ field.name }}_elt = str(memory[current_offset:current_offset + {{ field.name }}_elt_size])
-                    current_offset += {{ field.name }}_elt_size
-            {%- elif field.fixed_width == true %}
+                {%- if field.fixed_width == true %}
                     {{ field.name }}_elt = (<{{ field.c_type }} *>&memory[current_offset])[0]
                     current_offset += sizeof({{ field.c_type }})
-            {%- elif field.var_width == true %}
+                {%- elif field.var_width == true %}
                     {{ field.name }}_elt = {{ field.getter }}(memory, &current_offset)
+                {%- endif %}
+                    self._{{ field.name }}._append({{ field.name }}_elt)
+            {%- else %}
+                {%- if field.type == 'message' %}
+                {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
+                {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
+                current_offset += {{ field.name }}_elt._protobuf_deserialize(&memory[current_offset], {{ field.name }}_elt_size)
+                {%- elif field.type == 'string' %}
+                {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
+                {{ field.name }}_elt = str(memory[current_offset:current_offset + {{ field.name }}_elt_size])
+                current_offset += {{ field.name }}_elt_size
+                {%- elif field.fixed_width == true %}
+                {{ field.name }}_elt = (<{{ field.c_type }} *>&memory[current_offset])[0]
+                current_offset += sizeof({{ field.c_type }})
+                {%- elif field.var_width == true %}
+                {{ field.name }}_elt = {{ field.getter }}(memory, &current_offset)
+                {%- endif %}
+                {%- if field.type != 'message' and field.type != 'string' %}
+                self._{{ field.name }}._append({{ field.name }}_elt)
+                {%- else %}
+                list.append(self._{{ field.name }}, {{ field.name }}_elt)
+                {%- endif %}
             {%- endif %}
-                    self._{{ field.name }}.append({{ field.name }}_elt)
 
         {%- elif field.type == 'message' %}
                 {{ field.name }}_size = get_varint64(memory, &current_offset)
@@ -262,15 +305,10 @@ cdef class {{ name }}:
 
         {%- endif %}
 
-        {%- if field.modifier != 'repeated' and field.type != 'message' and field.type != 'enum' %}
-                self.__{{ field.name }}_set = 1
-        {%- endif %}
     {%- endfor %}
-            else:
-                continue
     {%- endif %}
 
-        self.__is_present_in_parent = True
+        self._is_present_in_parent = True
 
         return current_offset
 
@@ -288,7 +326,7 @@ cdef class {{ name }}:
         elif field_name == '{{ field.name }}':
         {%- endif %}
             {%- if field.type != 'message' and field.modifier != 'repeated' %}
-            self._{{ field.name }}_isDefault = True
+            self._{{ field.name }}_isSet = False
             {%- else %}
             self._{{ field.name }}._SetListener(None)
             {%- endif -%}
@@ -317,19 +355,16 @@ cdef class {{ name }}:
             {%- else %}
             self._{{ field.name }} = 0
             {%- endif %}
-            {%- if field.modifier != 'repeated' and field.type != 'message' %}
-            self.__{{ field.name }}_set = 0
-            {%- endif %}
     {%- endfor %}
 
         self._Modified()
 
-    cpdef void CopyFrom(self, {{ name }} other_msg):
+    def CopyFrom(self, other_msg):
         """
         Copies the content of the specified message into the current message.
 
         Params:
-            other_msg ({{ name }}): Message to copy into the current one.
+            other_msg: Message to copy into the current one.
         """
         if self is other_msg:
             return
@@ -339,13 +374,16 @@ cdef class {{ name }}:
     def HasField(self, field_name):
         """
         Checks if a certain field is set for the message.
+
+        Params:
+            field_name (str): The name of the field to check.
         """
     {%- for field in message.fields|rejectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
         if field_name == '{{ field.name }}':
         {%- if field.type == 'message' %}
             return self._{{ field.name }}._is_present_in_parent
         {%- else %}
-            return self.__{{ field.name }}_set != 0
+            return self._{{ field.name }}_isSet
         {%- endif %}
     {%- endfor %}
         raise ValueError('Protocol message has no singular "%s" field.' % field_name)
@@ -360,45 +398,84 @@ cdef class {{ name }}:
         """
     {%- for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
         {%- if field.type == 'message' %}
-        if not self._{{ field.name }}._is_present_in_parent:
+        if not self._{{ field.name }}.IsInitialized():
         {%- else %}
-        if self.__{{ field.name }}_set == 0:
+        if not self._{{ field.name }}_isSet:
         {%- endif %}
             return False
     {%- endfor %}
 
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'optional')|sort(attribute='index') %}
+        if self._{{ field.name }}._is_present_in_parent and not self._{{ field.name }}.IsInitialized():
+            return False
+    {%- endfor %}
+
+    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        for {{ field.name }}_msg in self._{{ field.name }}:
+            if not {{ field.name }}_msg.IsInitialized():
+                return False
+    {%- endfor %}
+
         return True
 
-    cpdef void MergeFrom(self, {{ name }} other_msg):
+    def MergeFrom(self, other_msg):
         """
         Merges the contents of the specified message into the current message.
 
         Params:
-            other_msg ({{ name }}): Message to merge into the current message.
+            other_msg: Message to merge into the current message.
         """
-    {%- for field in message.fields|sort(attribute='index') %}
+        if not isinstance(other_msg, {{ name }}) and not hasattr(other_msg, 'HasField'):
+            raise TypeError("Parameter to MergeFrom() must be an instance of same message class: expected {{ name }} got %s" % type(other_msg).__name__)
+
+    {% for field in message.fields|sort(attribute='index') %}
         {%- if field.modifier == 'repeated' and field.type == 'message' %}
-        for {{ field.name }}_msg in other_msg.{{ field.name }}:
-            {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
-            {{ field.name }}_elt.MergeFrom({{ field.name }}_msg)
-            self.{{ field.name }}.append({{ field.name }}_elt)
+        if hasattr(other_msg, '{{ field.name }}'):
+            for {{ field.name }}_msg in other_msg.{{ field.name }}:
+                {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
+                {{ field.name }}_elt.MergeFrom({{ field.name }}_msg)
+                list.append(self.{{ field.name }}, {{ field.name }}_elt)
         {%- elif field.modifier == 'repeated' %}
-        self._{{ field.name }}.extend(other_msg.{{ field.name }})
+        if hasattr(other_msg, '{{ field.name }}'):
+            self._{{ field.name }}.extend(other_msg.{{ field.name }})
         {%- elif field.type == 'message' %}
-        if other_msg.{{ field.name }}._is_present_in_parent:
+        if other_msg.HasField('{{ field.name }}'):
             self._{{ field.name }}.MergeFrom(other_msg.{{ field.name }})
         {%- else %}
         if other_msg.HasField('{{ field.name }}'):
-            {%- if field.type == 'enum' %}
             self.{{ field.name }} = other_msg.{{ field.name }}
-            {%- else %}
-            self._{{ field.name }} = other_msg.{{ field.name }}
-            self.__{{ field.name }}_set = 1
-            {%- endif %}
+            self._{{ field.name }}_isSet = True
         {%- endif %}
     {%- endfor %}
 
-        self._Modified()
+        if not self._is_present_in_parent:
+            self._Modified()
+
+    def MergeFromString(self, data, size=None):
+        """
+        Merges serialized protocol buffer data into this message.
+
+        Params:
+            data (str): a string of binary data.
+            size (int): optional - the length of the data string
+
+        Returns:
+            int: the number of bytes processed during serialization
+        """
+        already_present_in_parent = self._is_present_in_parent
+
+        if size is None:
+            size = len(data)
+
+        buf = self._protobuf_deserialize(data, size)
+
+        if buf != size:
+            raise DecodeError("Truncated message")
+
+        if not already_present_in_parent:
+            self._Modified()
+
+        return buf
 
     def ParseFromString(self, data, size=None, reset=True):
         """
@@ -412,7 +489,9 @@ cdef class {{ name }}:
         Returns:
             int: the number of bytes processed during serialization
         """
-        if size == None:
+        already_present_in_parent = self._is_present_in_parent
+
+        if size is None:
             size = len(data)
 
         if reset:
@@ -423,41 +502,37 @@ cdef class {{ name }}:
         if buf != size:
             raise DecodeError("Truncated message")
 
-    {%- for field in message.fields|sort(attribute='index') %}
-        {%- if field.modifier == 'required' and field.default == None %}
-            {%- if field.type == 'message' %}
-        if not self._{{field.name}}._is_present_in_parent:
-            {%- else %}
-        if self.__{{ field.name }}_set == 0:
-            {%- endif %}
-            raise Exception("required field '{{ field.name }}' not parsed and does not have default")
-        {%- endif %}
-    {%- endfor %}
+        if not already_present_in_parent:
+            self._Modified()
 
-        self._Modified()
+        {{ find_initialization_errors(message) }}
 
         return buf
 
     @classmethod
     def FromString(cls, s):
         message = cls()
-        message.ParseFromString(s)
+        message.ParseFromString(s, reset=False)
         return message
 
     cdef void _protobuf_serialize(self, bytearray buf):
         cdef int key
         cdef int field_idx
         cdef int wire_type
+    {%- if message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
+        cdef int i
+        cdef int length
+    {%- endif %}
 
-    {%- for field in message.fields|sort(attribute='index') %}
+    {% for field in message.fields|sort(attribute='index') %}
+
         # {{ field.name }}
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
+        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_elt
         cdef bytearray {{ field.name }}_elt_buf
             {%- elif field.type in ('string', 'bytes') %}
         cdef str {{ field.name }}_elt
-            {%- elif field.type == 'message' %}
-        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_elt
             {%- elif field.type == 'enum' %}
         cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }} {{ field.name }}_elt
             {%- else %}
@@ -467,27 +542,17 @@ cdef class {{ name }}:
             {%- if field.packed == true and field.var_width == true %}
         cdef bytearray {{ field.name }}_buf = bytearray()
             {%- endif %}
-
-        if len(self._{{ field.name }}) > 0:
+        length = len(self._{{ field.name }})
+        if length:
 
         {%- elif field.type == 'message' %}
-        cdef bytearray {{ field.name }}_buf = bytearray()
-        self._{{ field.name }}._protobuf_serialize({{ field.name }}_buf)
-        if len({{ field.name }}_buf) > 0:
+        cdef bytearray {{ field.name }}_buf
+        if self._{{ field.name }}._is_present_in_parent:
 
-        {# !messages and !repeated fields can all have default values #}
-        {%- elif field.modifier != 'repeated'%}
-        if not self._{{ field.name }}_isDefault:
-
-        {%- elif field.modifier == 'required' and field.default == None %}
-        if self.__{{ field.name }}_set != 0:
-
-        {%- elif field.type == 'string' %}
-        if self._{{ field.name }} != "":
+        {#- !messages and !repeated fields can all have default values #}
         {%- else %}
-        if self._{{ field.name }} != 0:
+        if self._{{ field.name }}_isSet:
         {%- endif %}
-
             field_idx = {{ field.index }}
         {%- if field.modifier == 'repeated' and field.packed == true %}
             wire_type = 2
@@ -506,12 +571,14 @@ cdef class {{ name }}:
             {%- if field.packed == true %}
             set_varint64(key, buf)
                 {%- if field.fixed_width == true %}
-            set_varint64(len(self._{{ field.name }}) * sizeof({{ field.name }}_elt), buf)
-            for {{ field.name }}_elt in self._{{ field.name }}:
+            set_varint64(length * sizeof({{ field.name }}_elt), buf)
+            for i in range(length):
+                {{ field.name }}_elt = <{{ field.c_type }}>self._{{ field.name }}[i]
                 buf += (<unsigned char *>&{{ field.name }}_elt)[:sizeof({{ field.name }}_elt)]
 
                 {%- elif field.var_width == true %}
-            for {{ field.name }}_elt in self._{{ field.name }}:
+            for i in range(length):
+                {{ field.name }}_elt = <{{ field.c_type }}>self._{{ field.name }}[i]
                 {{ field.setter }}({{ field.name }}_elt, {{ field.name }}_buf)
 
             set_varint64(len({{ field.name }}_buf), buf)
@@ -519,23 +586,30 @@ cdef class {{ name }}:
                 {%- endif %}
 
             {%- else %}
-            for {{ field.name }}_elt in self._{{ field.name }}:
+            for i in range(length):
                 set_varint64(key, buf)
                 {%- if field.type == 'string' %}
+                {{ field.name }}_elt = <str>self._{{ field.name }}[i]
                 set_varint64(len({{ field.name }}_elt), buf)
                 buf += {{ field.name }}_elt
                 {%- elif field.type == 'message' %}
-                {{ field.name }}_elt_buf = {{ field.name }}_elt.SerializeToString()
+                {{ field.name }}_elt = <{% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}>self._{{ field.name }}[i]
+                {{ field.name }}_elt_buf = bytearray()
+                {{ field.name }}_elt._protobuf_serialize({{ field.name }}_elt_buf)
                 set_varint64(len({{ field.name }}_elt_buf), buf)
                 buf += {{ field.name }}_elt_buf
                 {%- elif field.fixed_width == true %}
+                {{ field.name }}_elt = <{{ field.c_type }}>self._{{ field.name }}[i]
                 buf += (<unsigned char *>&{{ field.name }}_elt)[:sizeof({{ field.name }}_elt)]
                 {%- elif field.var_width == true %}
+                {{ field.name }}_elt = <{{ field.c_type }}>self._{{ field.name }}[i]
                 {{ field.setter }}({{ field.name }}_elt, buf)
                 {%- endif %}
             {%- endif %}
 
         {%- elif field.type == 'message' %}
+            {{ field.name }}_buf = bytearray()
+            self._{{ field.name }}._protobuf_serialize({{ field.name }}_buf)
             set_varint64(key, buf)
             set_varint64(len({{ field.name }}_buf), buf)
             buf += {{ field.name }}_buf
@@ -557,8 +631,8 @@ cdef class {{ name }}:
     {%- endfor %}
 
     cpdef void _Modified(self):
-        if not self.__is_present_in_parent:
-            self.__is_present_in_parent = True
+        if not self._is_present_in_parent:
+            self._is_present_in_parent = True
             (<object> self._listener)._Modified()
 
     cpdef void _SetListener(self, listener):
@@ -574,17 +648,19 @@ cdef class {{ name }}:
         Returns:
             bytearray: a bytearray of binary data
         """
-    {%- for field in message.fields|sort(attribute='index') %}
-        {%- if field.modifier == 'required' and field.default == None %}
-            {%- if field.type == 'message' %}
-        if not self._{{ field.name }}._is_present_in_parent:
-            {%- else %}
-        if self.__{{ field.name }}_set == 0:
-            {%- endif %}
-            raise Exception("required field '{{ field.name }}' not initialized and does not have default")
-        {%- endif %}
-    {%- endfor %}
+        {{ find_initialization_errors(message) }}
 
+        buf = bytearray()
+        self._protobuf_serialize(buf)
+        return buf
+
+    cpdef bytearray SerializePartialToString(self):
+        """
+        Serialize the message class into a bytearray of protobuf encoded binary data.
+
+        Returns:
+            bytearray: a bytearray of binary data
+        """
         buf = bytearray()
         self._protobuf_serialize(buf)
         return buf
@@ -598,7 +674,7 @@ cdef class {{ name }}:
             size (int): optional - the length of the data string
             reset (bool): optional - whether to reset to default values before serializing
         """
-        if size == None:
+        if size is None:
             size = len(data)
         d = json.loads(data[:size])
         self.ParseFromDict(d, reset)
@@ -642,18 +718,13 @@ cdef class {{ name }}:
             pass
     {%- endfor %}
 
-    {%- for field in message.fields|sort(attribute='index') %}
-        {%- if field.modifier == 'required' and field.default == None %}
-            {%- if field.type == 'message' %}
-        if not self._{{ field.name }}._is_present_in_parent:
-            {%- else %}
-        if self.__{{ field.name }}_set == 0:
-            {%- endif %}
-            raise Exception("required field '{{ field.name }}' not parsed and does not have default")
-        {%- endif %}
-    {%- endfor %}
-
         self._Modified()
+
+    {#- The recursive calls to ParseFromDict will check required fields of sub-messages including repeated messages #}
+    {%- for field in message.fields|rejectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+        if not self._{{ field.name }}_isSet:
+            raise Exception("required field '{{ field.name }}' not initialized and does not have default")
+    {%- endfor %}
 
         return
 
@@ -666,15 +737,10 @@ cdef class {{ name }}:
         """
         out = {}
 
-    {%- for field in message.fields|sort(attribute='index') %}
-        {%- if field.modifier == 'required' and field.default == None %}
-            {%- if field.type == 'message' %}
-        if not self._{{ field.name }}._is_present_in_parent:
-            {%- else %}
-        if self.__{{ field.name }}_set == 0:
-            {%- endif %}
+    {#- The recursive calls to SerializeToDict will check required fields of sub-messages including repeated messages #}
+    {%- for field in message.fields|rejectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+        if not self._{{ field.name }}_isSet:
             raise Exception("required field '{{ field.name }}' not initialized and does not have default")
-        {%- endif %}
     {%- endfor %}
 
     {%- for field in message.fields|sort(attribute='index') %}
@@ -689,7 +755,7 @@ cdef class {{ name }}:
         if {{ field.name }}_dict != {}:
             out["{{ field.name }}"] = {{ field.name }}_dict
         {%- elif field.modifier == 'required' %}
-        if self.__{{ field.name }}_set != 0:
+        if self._{{ field.name }}_isSet:
             out["{{ field.name }}"] = self.{{ field.name }}
         {%- elif field.default != None %}
             {%- if field.type == 'string' %}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -59,26 +59,27 @@ cdef class {{ name }}:
 
     def __init__(self, **kwargs):
         self.reset()
-        for field_name, field_value in kwargs.{%- if version_major == 2 -%} iter {%- endif -%} items():
-            try:
+        if kwargs:
+            for field_name, field_value in kwargs.{%- if version_major == 2 -%} iter {%- endif -%} items():
+                try:
             {%- if message.fields|selectattr('type', 'equalto', 'message')|rejectattr('modifier', 'equalto', 'repeated')|first is defined %}
-                if field_name in ('{{ message.fields|selectattr('type', 'equalto', 'message')|rejectattr('modifier', 'equalto', 'repeated')|join("','", attribute='name') }}',):
-                    getattr(self, field_name).MergeFrom(field_value)
+                    if field_name in ('{{ message.fields|selectattr('type', 'equalto', 'message')|rejectattr('modifier', 'equalto', 'repeated')|join("','", attribute='name') }}',):
+                        getattr(self, field_name).MergeFrom(field_value)
             {%- endif %}
             {%- if message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
-                {% if message.fields|selectattr('type', 'equalto', 'message')|rejectattr('modifier', 'equalto', 'repeated')|first is defined -%}el{%- endif -%}
-                if field_name in ('{{ message.fields|selectattr('modifier', 'equalto', 'repeated')|join("','", attribute='name') }}',):
-                    getattr(self, field_name).extend(field_value)
+                    {% if message.fields|selectattr('type', 'equalto', 'message')|rejectattr('modifier', 'equalto', 'repeated')|first is defined -%}el{%- endif -%}
+                    if field_name in ('{{ message.fields|selectattr('modifier', 'equalto', 'repeated')|join("','", attribute='name') }}',):
+                        getattr(self, field_name).extend(field_value)
             {%- endif %}
             {%- if (message.fields|selectattr('type', 'equalto', 'message')|first is defined or
                     message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined) %}
-                else:
-                    setattr(self, field_name, field_value)
+                    else:
+                        setattr(self, field_name, field_value)
             {%- else %}
-                setattr(self, field_name, field_value)
+                    setattr(self, field_name, field_value)
             {%- endif %}
-            except AttributeError:
-                raise ValueError('Protocol message has no "%s" field.' % (field_name,))
+                except AttributeError:
+                    raise ValueError('Protocol message has no "%s" field.' % (field_name,))
         return
 
     def __str__(self):
@@ -100,7 +101,7 @@ cdef class {{ name }}:
             components.append('}')
         return '\n'.join(components)
 
-    cpdef reset(self):
+    cpdef void reset(self):
         # reset values and populate defaults
     {% for field in message.fields %}
         {%- if field.type != 'message' and field.modifier != 'repeated' %}
@@ -115,10 +116,11 @@ cdef class {{ name }}:
             {%- elif field.type == 'string' %}
         self._{{ field.name }} = TypedList(str, self)
             {%- else %}
-        self._{{ field.name }} = {{ field.list_type }}(message_listener=self)
+        self._{{ field.name }} = {{ field.list_type }}.__new__({{ field.list_type }}, message_listener=self)
             {%- endif %}
         {%- elif field.type == 'message' %}
-        self._{{ field.name }} = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
+        self._{{ field.name }} = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}.__new__({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }})
+        self._{{ field.name }}.reset()
         self._{{ field.name }}._SetListener(self)
         {%- elif field.default != None %}
             {%- if field.type == 'string' %}
@@ -314,7 +316,8 @@ cdef class {{ name }}:
     cpdef void Clear(self):
         """Clears all data that was set in the message."""
         self.reset()
-        self._Modified()
+        if not self._is_present_in_parent:
+            self._Modified()
 
     cpdef void ClearField(self, field_name):
         """Clears the contents of a given field."""

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -17,35 +17,6 @@ from {{ import }}_proto cimport *
     {%- endfor %}
 {%- endmacro %}
 
-{%- macro find_initialization_errors(message) %}
-    {%- if message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
-        cdef int i
-    {%- endif %}
-    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
-        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_msg
-    {%- endfor %}
-
-    {% for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
-        {%- if field.type == 'message' %}
-        if not self._{{ field.name }}.IsInitialized():
-        {%- else %}
-        if not self._{{ field.name }}_isSet:
-        {%- endif %}
-            raise Exception("required field '{{ field.name }}' not initialized and does not have default")
-    {%- endfor %}
-
-    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'optional')|sort(attribute='index') %}
-        if self._{{ field.name }}._is_present_in_parent and not self._{{ field.name }}.IsInitialized():
-            raise Exception("Message {{ name }} is missing required field: {{ field.name }}")
-    {%- endfor %}
-
-    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
-        for i in len(self._{{ field.name }}):
-            {{ field.name }}_msg = <{% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}>self._{{ field.name }}[i]
-            if not {{ field.name }}_msg.IsInitialized():
-                raise Exception("Message {{ name }} is missing required field: {{ field.name }}[%d]" % i)
-    {%- endfor %}
-{%- endmacro %}
 
 {%- macro classdef(name, message) %}
 cdef class {{ name }}:

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -92,7 +92,7 @@ cdef class {{ name }}:
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
         self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}, self)
-            {%- elif field.type == 'string' %}
+            {%- elif field.type in ('string', 'bytes') %}
         self._{{ field.name }} = TypedList(str, self)
             {%- else %}
         self._{{ field.name }} = {{ field.list_type }}.__new__({{ field.list_type }}, listener=self)
@@ -102,14 +102,14 @@ cdef class {{ name }}:
         self._{{ field.name }}.reset()
         self._{{ field.name }}._listener = <PyObject *>self
         {%- elif field.default != None %}
-            {%- if field.type == 'string' %}
+            {%- if field.type in ('string', 'bytes') %}
         self._{{ field.name }} = "{{ field.default }}"
             {%- elif field.type == 'enum' %}
         self._{{ field.name }} = _{{ field.enum_default }}
             {%- else %}
         self._{{ field.name }} = {{ field.default }}
             {%- endif %}
-        {%- elif field.type == 'string' %}
+        {%- elif field.type in ('string', 'bytes') %}
         self._{{ field.name }} = ""
         {%- elif field.type == 'enum' and field.enum_def != None %}
         self._{{ field.name }} = _{{ field.enum_def.fields[0].name }}
@@ -134,7 +134,7 @@ cdef class {{ name }}:
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
             self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}, self)
-            {%- elif field.type == 'string' %}
+            {%- elif field.type in ('string', 'bytes') %}
             self._{{ field.name }} = TypedList(str, self)
             {%- else %}
             self._{{ field.name }} = {{ field.list_type }}(listener=self)
@@ -143,16 +143,16 @@ cdef class {{ name }}:
             {%- if field.type == 'enum' and field.enum_def != None %}
                 {%- for enum_field in field.enum_def.fields %}
                     {%- if loop.index == 1 %}
-                if value == {{ enum_field.value }}:
+                if val == {{ enum_field.value }}:
                     {%- else %}
-                elif value == {{ enum_field.value }}:
+                elif val == {{ enum_field.value }}:
                     {%- endif %}
                     self._{{ field.name }}.append(_{{ enum_field.name }})
                 {% endfor %}
                 else:
                     raise Exception("not a valid value for enum {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }}")
-            {%- elif field.type == 'string' %}
-                if type(val) == unicode:
+            {%- elif field.type in ('string', 'bytes') %}
+                if type(val) is unicode:
                     self._{{ field.name }}.append(str(val))
                 else:
                     self._{{ field.name }}.append(val)
@@ -171,8 +171,8 @@ cdef class {{ name }}:
                 {% endfor %}
             else:
                 raise Exception("not a valid value for enum {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }}")
-            {%- elif field.type == 'string' %}
-            if type(value) == unicode:
+            {%- elif field.type in ('string', 'bytes') %}
+            if type(value) is unicode:
                 self._{{ field.name }} = str(value)
             else:
                 self._{{ field.name }} = value
@@ -192,7 +192,8 @@ cdef class {{ name }}:
         cdef int64_t key
         cdef int64_t field_idx
     {%- if message.fields|selectattr('type', 'equalto', 'message')|first is defined or
-           message.fields|selectattr('type', 'equalto', 'string')|first is defined %}
+           message.fields|selectattr('type', 'equalto', 'string')|first is defined or
+           message.fields|selectattr('type', 'equalto', 'bytes')|first is defined %}
         cdef int64_t field_size
     {%- endif %}
         # cdef int wire_type
@@ -204,7 +205,7 @@ cdef class {{ name }}:
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
         cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_elt
-            {%- elif field.type == 'string' %}
+            {%- elif field.type in ('string', 'bytes') %}
         cdef str {{ field.name }}_elt
             {%- elif field.type == 'enum' %}
         cdef int32_t {{ field.name }}_elt
@@ -250,7 +251,7 @@ cdef class {{ name }}:
                 {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
                 field_size = get_varint64(memory, &current_offset)
                 current_offset += {{ field.name }}_elt._protobuf_deserialize(memory+current_offset, field_size)
-                {%- elif field.type == 'string' %}
+                {%- elif field.type in ('string', 'bytes') %}
                 field_size = get_varint64(memory, &current_offset)
                 {{ field.name }}_elt = str(memory[current_offset:current_offset + field_size])
                 current_offset += field_size
@@ -260,7 +261,7 @@ cdef class {{ name }}:
                 {%- elif field.var_width == true %}
                 {{ field.name }}_elt = {{ field.getter }}(memory, &current_offset)
                 {%- endif %}
-                {%- if field.type != 'message' and field.type != 'string' %}
+                {%- if field.type != 'message' and field.type not in ('string', 'bytes') %}
                 self._{{ field.name }}._append({{ field.name }}_elt)
                 {%- else %}
                 list.append(self._{{ field.name }}, {{ field.name }}_elt)
@@ -271,7 +272,7 @@ cdef class {{ name }}:
                 field_size = get_varint64(memory, &current_offset)
                 current_offset += self._{{ field.name }}._protobuf_deserialize(memory+current_offset, field_size)
 
-        {%- elif field.type == 'string' %}
+        {%- elif field.type in ('string', 'bytes') %}
                 field_size = get_varint64(memory, &current_offset)
                 self._{{ field.name }} = str(memory[current_offset:current_offset + field_size])
                 current_offset += field_size
@@ -301,7 +302,7 @@ cdef class {{ name }}:
         if not self._is_present_in_parent:
             self._Modified()
 
-    cpdef void ClearField(self, str field_name):
+    cpdef void ClearField(self, field_name):
         """Clears the contents of a given field."""
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if loop.index == 1 %}
@@ -317,7 +318,7 @@ cdef class {{ name }}:
             {%- if field.modifier == 'repeated' %}
                 {%- if field.type == 'message' %}
             self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}, self)
-                {%- elif field.type == 'string' %}
+                {%- elif field.type in ('string', 'bytes') %}
             self._{{ field.name }} = TypedList(str, self)
                 {%- else %}
             self._{{ field.name }} = {{ field.list_type }}.__new__({{ field.list_type }}, listener=self)
@@ -327,14 +328,14 @@ cdef class {{ name }}:
             self._{{ field.name }}.reset()
             self._{{ field.name }}._listener = <PyObject *>self
             {%- elif field.default != None %}
-                {%- if field.type == 'string' %}
+                {%- if field.type in ('string', 'bytes') %}
             self._{{ field.name }} = "{{ field.default }}"
                 {%- elif field.type == 'enum' %}
             self._{{ field.name }} = _{{ field.enum_default }}
                 {%- else %}
             self._{{ field.name }} = {{ field.default }}
                 {%- endif %}
-            {%- elif field.type == 'string' %}
+            {%- elif field.type in ('string', 'bytes') %}
             self._{{ field.name }} = ""
             {%- elif field.type == 'enum' and field.enum_def != None %}
             self._{{ field.name }} = _{{ field.enum_def.fields[0].name }}
@@ -342,23 +343,29 @@ cdef class {{ name }}:
             self._{{ field.name }} = 0
             {%- endif %}
     {%- endfor %}
+    {%- if message.fields|first is defined %}
+        else:
+            raise ValueError('Protocol message has no "%s" field.' % field_name)
 
         if not self._is_present_in_parent:
             self._Modified()
+    {%- else %}
+        raise ValueError('Protocol message has no "%s" field.' % field_name)
+    {%- endif %}
 
-    def CopyFrom(self, other_msg):
+    cpdef void CopyFrom(self, {{ name }} other_msg):
         """
         Copies the content of the specified message into the current message.
 
         Params:
-            other_msg: Message to copy into the current one.
+            other_msg ({{ name }}): Message to copy into the current one.
         """
         if self is other_msg:
             return
         self.reset()
         self.MergeFrom(other_msg)
 
-    cpdef bint HasField(self, str field_name) except -1:
+    cpdef bint HasField(self, field_name) except -1:
         """
         Checks if a certain field is set for the message.
 
@@ -413,32 +420,41 @@ cdef class {{ name }}:
 
         return True
 
-    def MergeFrom(self, other_msg):
+    cpdef void MergeFrom(self, {{ name }} other_msg):
         """
         Merges the contents of the specified message into the current message.
 
         Params:
             other_msg: Message to merge into the current message.
         """
-        if not isinstance(other_msg, {{ name }}) and not hasattr(other_msg, 'HasField'):
-            raise TypeError("Parameter to MergeFrom() must be an instance of same message class: expected {{ name }} got %s" % type(other_msg).__name__)
+    {%- if message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
+        cdef int i
+    {%- endif %}
+    {%- for field in message.fields|sort(attribute='index') %}
+        {%- if field.modifier == 'repeated' and field.type == 'message' %}
+        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_elt
+        {%- endif %}
+    {%- endfor %}
+
+        if self is other_msg:
+            return
 
     {% for field in message.fields|sort(attribute='index') %}
         {%- if field.modifier == 'repeated' and field.type == 'message' %}
-        if hasattr(other_msg, '{{ field.name }}'):
-            for {{ field.name }}_msg in other_msg.{{ field.name }}:
-                {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
-                {{ field.name }}_elt.MergeFrom({{ field.name }}_msg)
-                list.append(self.{{ field.name }}, {{ field.name }}_elt)
+        for i in range(len(other_msg._{{ field.name }})):
+            {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
+            {{ field.name }}_elt.MergeFrom(other_msg._{{ field.name }}[i])
+            list.append(self._{{ field.name }}, {{ field.name }}_elt)
+        {%- elif field.modifier == 'repeated' and field.type in ('string', 'bytes') %}
+        self._{{ field.name }} += other_msg._{{ field.name }}
         {%- elif field.modifier == 'repeated' %}
-        if hasattr(other_msg, '{{ field.name }}'):
-            self._{{ field.name }}.extend(other_msg.{{ field.name }})
+        self._{{ field.name }}.extend(other_msg._{{ field.name }})
         {%- elif field.type == 'message' %}
-        if other_msg.HasField('{{ field.name }}'):
-            self._{{ field.name }}.MergeFrom(other_msg.{{ field.name }})
+        if other_msg._{{ field.name }}._is_present_in_parent:
+            self._{{ field.name }}.MergeFrom(other_msg._{{ field.name }})
         {%- else %}
-        if other_msg.HasField('{{ field.name }}'):
-            self.{{ field.name }} = other_msg.{{ field.name }}
+        if other_msg._{{ field.name }}_isSet:
+            self._{{ field.name }} = other_msg._{{ field.name }}
             self._{{ field.name }}_isSet = True
         {%- endif %}
     {%- endfor %}
@@ -578,7 +594,7 @@ cdef class {{ name }}:
             field_idx = {{ field.index }}
         {%- if field.modifier == 'repeated' and field.packed == true %}
             wire_type = 2
-        {%- elif field.type in ('message', 'string') %}
+        {%- elif field.type in ('message', 'string', 'bytes') %}
             wire_type = 2
         {%- elif field.type in ('fixed64', 'sfixed64', 'double') %}
             wire_type = 1
@@ -610,7 +626,7 @@ cdef class {{ name }}:
             {%- else %}
             for i in range(length):
                 set_varint64(key, buf)
-                {%- if field.type == 'string' %}
+                {%- if field.type in ('string', 'bytes') %}
                 {{ field.name }}_elt = <str>self._{{ field.name }}[i]
                 set_varint64(len({{ field.name }}_elt), buf)
                 buf += {{ field.name }}_elt
@@ -636,7 +652,7 @@ cdef class {{ name }}:
             set_varint64(len({{ field.name }}_buf), buf)
             buf += {{ field.name }}_buf
 
-        {%- elif field.type == 'string' %}
+        {%- elif field.type in ('string', 'bytes') %}
             set_varint64(key, buf)
             set_varint64(len(self._{{ field.name }}), buf)
             buf += self._{{ field.name }}
@@ -706,6 +722,13 @@ cdef class {{ name }}:
         cdef bytearray buf = bytearray()
         self._protobuf_serialize(buf)
         return buf
+
+    def SetInParent(self):
+        """
+        Mark this an present in the parent.
+        """
+        if not self._is_present_in_parent:
+            self._Modified()
 
     def ParseFromJson(self, data, size=None, reset=True):
         """
@@ -800,7 +823,7 @@ cdef class {{ name }}:
         if self._{{ field.name }}_isSet:
             out["{{ field.name }}"] = self.{{ field.name }}
         {%- elif field.default != None %}
-            {%- if field.type == 'string' %}
+            {%- if field.type in ('string', 'bytes') %}
         if self.{{ field.name }} != "{{ field.default }}":
             out["{{ field.name }}"] = self.{{ field.name }}
             {%- else %}
@@ -808,7 +831,7 @@ cdef class {{ name }}:
             out["{{ field.name }}"] = self.{{ field.name }}
             {%- endif %}
         {%- else %}
-            {%- if field.type == 'string' %}
+            {%- if field.type in ('string', 'bytes') %}
         if self.{{ field.name }} != "":
             out["{{ field.name }}"] = self.{{ field.name }}
             {%- else %}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -1,11 +1,11 @@
 from libc.stdint cimport *
 from libc.string cimport *
+from cpython.ref cimport PyObject
 
 from pyrobuf_list cimport *
 from pyrobuf_util cimport *
 
 import json
-import weakref
 
 {%- for import in imports %}
 from {{ import }}_proto cimport *
@@ -20,10 +20,23 @@ from {{ import }}_proto cimport *
 {%- macro classdef(name, message) %}
 cdef class {{ name }}:
 
+    def __cinit__(self):
+        self._listener = <PyObject *>null_listener
+
+    {% if (message.fields|selectattr('type', 'equalto', 'message')|first is defined or
+           message.fields|selectattr('modifier', 'equalto', 'repeated')|first is defined) %}
+    def __dealloc__(self):
+        # Remove any references to self from child messages or repeated fields
+    {%- for field in message.fields %}
+        {%- if field.type == 'message' or field.modifier == 'repeated' %}
+        if self._{{ field.name }} is not None:
+            self._{{ field.name }}._SetListener(None)
+        {%- endif %}
+    {%- endfor %}
+    {%- endif %}
+
     def __init__(self):
         self.reset()
-        self._is_present_in_parent = False
-        self._listener = null_listener
         return
 
     def __str__(self):
@@ -50,6 +63,9 @@ cdef class {{ name }}:
     {% for field in message.fields %}
         {%- if field.type != 'message' and field.modifier != 'repeated' %}
         self._{{ field.name }}_isDefault = True
+        {%- else %}
+        if self._{{ field.name }} is not None:
+            self._{{ field.name }}._SetListener(None)
         {%- endif -%}
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
@@ -89,9 +105,12 @@ cdef class {{ name }}:
             return self._{{ field.name }}
 
         def __set__(self, value):
-            {%- if field.type != 'message' and field.modifier != 'repeated' %}
+        {%- if field.type != 'message' and field.modifier != 'repeated' %}
             self._{{ field.name }}_isDefault = False
-            {%- endif -%}
+        {%- else %}
+            if self._{{ field.name }} is not None:
+                self._{{ field.name }}._SetListener(None)
+        {%- endif -%}
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
             self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}, self)
@@ -144,9 +163,13 @@ cdef class {{ name }}:
         {%- if field.modifier != 'repeated' and field.type != 'message' %}
             self.__{{ field.name }}_set = 1
         {%- endif %}
-            if not self._is_present_in_parent:
+            if not self.__is_present_in_parent:
                 self._Modified()
     {% endfor %}
+
+    property _is_present_in_parent:
+        def __get__(self):
+            return self.__is_present_in_parent
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size):
         cdef int current_offset = 0
@@ -189,7 +212,7 @@ cdef class {{ name }}:
             elif field_idx == {{ field.index }}:
         {%- endif %}
 
-        {%- if field.modifier != 'repeated' and field.type != 'message'%}
+        {%- if field.modifier != 'repeated' and field.type != 'message' and field.type != 'enum' %}
                 self._{{field.name}}_isDefault = False
         {% endif -%}
 
@@ -205,7 +228,7 @@ cdef class {{ name }}:
             {%- if field.type == 'message' %}
                     {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
                     {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
-                    current_offset += {{ field.name }}_elt._protobuf_deserialize(memory[current_offset:current_offset + {{ field.name }}_elt_size], {{ field.name }}_elt_size)
+                    current_offset += {{ field.name }}_elt._protobuf_deserialize(&memory[current_offset], {{ field.name }}_elt_size)
             {%- elif field.type == 'string' %}
                     {{ field.name }}_elt_size = get_varint64(memory, &current_offset)
                     {{ field.name }}_elt = str(memory[current_offset:current_offset + {{ field.name }}_elt_size])
@@ -220,7 +243,7 @@ cdef class {{ name }}:
 
         {%- elif field.type == 'message' %}
                 {{ field.name }}_size = get_varint64(memory, &current_offset)
-                current_offset += self._{{ field.name }}._protobuf_deserialize(memory[current_offset:current_offset + {{ field.name }}_size], {{ field.name }}_size)
+                current_offset += self._{{ field.name }}._protobuf_deserialize(&memory[current_offset], {{ field.name }}_size)
 
         {%- elif field.type == 'string' %}
                 {{ field.name }}_size = get_varint64(memory, &current_offset)
@@ -239,7 +262,7 @@ cdef class {{ name }}:
 
         {%- endif %}
 
-        {%- if field.modifier != 'repeated' and field.type != 'message' %}
+        {%- if field.modifier != 'repeated' and field.type != 'message' and field.type != 'enum' %}
                 self.__{{ field.name }}_set = 1
         {%- endif %}
     {%- endfor %}
@@ -247,16 +270,16 @@ cdef class {{ name }}:
                 continue
     {%- endif %}
 
-        self._is_present_in_parent = True
+        self.__is_present_in_parent = True
 
         return current_offset
 
-    def Clear(self):
+    cpdef void Clear(self):
         """Clears all data that was set in the message."""
         self.reset()
         self._Modified()
 
-    def ClearField(self, field_name):
+    cpdef void ClearField(self, field_name):
         """Clears the contents of a given field."""
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if loop.index == 1 %}
@@ -266,6 +289,8 @@ cdef class {{ name }}:
         {%- endif %}
             {%- if field.type != 'message' and field.modifier != 'repeated' %}
             self._{{ field.name }}_isDefault = True
+            {%- else %}
+            self._{{ field.name }}._SetListener(None)
             {%- endif -%}
             {%- if field.modifier == 'repeated' %}
                 {%- if field.type == 'message' %}
@@ -299,12 +324,12 @@ cdef class {{ name }}:
 
         self._Modified()
 
-    def CopyFrom(self, other_msg):
+    cpdef void CopyFrom(self, {{ name }} other_msg):
         """
         Copies the content of the specified message into the current message.
 
         Params:
-            other_msg: Message to copy into the current one.
+            other_msg ({{ name }}): Message to copy into the current one.
         """
         if self is other_msg:
             return
@@ -344,18 +369,13 @@ cdef class {{ name }}:
 
         return True
 
-    def MergeFrom(self, other_msg):
+    cpdef void MergeFrom(self, {{ name }} other_msg):
         """
         Merges the contents of the specified message into the current message.
 
         Params:
-            other_msg: Message to merge into the current message.
+            other_msg ({{ name }}): Message to merge into the current message.
         """
-        if not isinstance(other_msg, {{ name }}):
-            raise TypeError(
-                "Parameter to MergeFrom() must be instance of same class: "
-                "expected %s got %s." % ('{{ name }}', type(other_msg).__name__))
-
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if field.modifier == 'repeated' and field.type == 'message' %}
         for {{ field.name }}_msg in other_msg.{{ field.name }}:
@@ -537,15 +557,15 @@ cdef class {{ name }}:
     {%- endfor %}
 
     cpdef void _Modified(self):
-        if not self._is_present_in_parent:
-            self._is_present_in_parent = True
-            self._listener._Modified()
+        if not self.__is_present_in_parent:
+            self.__is_present_in_parent = True
+            (<object> self._listener)._Modified()
 
     cpdef void _SetListener(self, listener):
         if listener is None:
-            self._listener = null_listener
+            self._listener = <PyObject *>null_listener
         else:
-            self._listener = weakref.proxy(listener)
+            self._listener = <PyObject *>listener
 
     def SerializeToString(self):
         """

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -5,6 +5,7 @@ from pyrobuf_list cimport *
 from pyrobuf_util cimport *
 
 import json
+import weakref
 
 {%- for import in imports %}
 from {{ import }}_proto cimport *
@@ -22,7 +23,7 @@ cdef class {{ name }}:
     def __init__(self):
         self.reset()
         self._is_present_in_parent = False
-        self._listener = None
+        self._listener = null_listener
         return
 
     def __str__(self):
@@ -538,11 +539,13 @@ cdef class {{ name }}:
     cpdef void _Modified(self):
         if not self._is_present_in_parent:
             self._is_present_in_parent = True
-            if self._listener is not None:
-                self._listener._Modified()
+            self._listener._Modified()
 
     cpdef void _SetListener(self, listener):
-        self._listener = listener
+        if listener is None:
+            self._listener = null_listener
+        else:
+            self._listener = weakref.proxy(listener)
 
     def SerializeToString(self):
         """

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -50,9 +50,9 @@ cdef class {{ name }}:
     def __dealloc__(self):
         # Remove any references to self from child messages or repeated fields
     {%- for field in message.fields %}
-        {%- if field.type == 'message' or field.modifier == 'repeated' %}
+        {%- if field.modifier == 'repeated' or field.type == 'message' %}
         if self._{{ field.name }} is not None:
-            self._{{ field.name }}._SetListener(None)
+            self._{{ field.name }}._listener = <PyObject *>null_listener
         {%- endif %}
     {%- endfor %}
     {%- endif %}
@@ -108,7 +108,7 @@ cdef class {{ name }}:
         self._{{ field.name }}_isSet = False
         {%- else %}
         if self._{{ field.name }} is not None:
-            self._{{ field.name }}._SetListener(None)
+            self._{{ field.name }}._listener = <PyObject *>null_listener
         {%- endif -%}
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
@@ -116,12 +116,12 @@ cdef class {{ name }}:
             {%- elif field.type == 'string' %}
         self._{{ field.name }} = TypedList(str, self)
             {%- else %}
-        self._{{ field.name }} = {{ field.list_type }}.__new__({{ field.list_type }}, message_listener=self)
+        self._{{ field.name }} = {{ field.list_type }}.__new__({{ field.list_type }}, listener=self)
             {%- endif %}
         {%- elif field.type == 'message' %}
         self._{{ field.name }} = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}.__new__({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }})
         self._{{ field.name }}.reset()
-        self._{{ field.name }}._SetListener(self)
+        self._{{ field.name }}._listener = <PyObject *>self
         {%- elif field.default != None %}
             {%- if field.type == 'string' %}
         self._{{ field.name }} = "{{ field.default }}"
@@ -150,7 +150,7 @@ cdef class {{ name }}:
             self._{{ field.name }}_isSet = True
         {%- else %}
             if self._{{ field.name }} is not None:
-                self._{{ field.name }}._SetListener(None)
+                self._{{ field.name }}._listener = <PyObject *>null_listener
         {%- endif -%}
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
@@ -158,7 +158,7 @@ cdef class {{ name }}:
             {%- elif field.type == 'string' %}
             self._{{ field.name }} = TypedList(str, self)
             {%- else %}
-            self._{{ field.name }} = {{ field.list_type }}(message_listener=self)
+            self._{{ field.name }} = {{ field.list_type }}(listener=self)
             {%- endif %}
             for val in value:
             {%- if field.type == 'enum' and field.enum_def != None %}
@@ -173,7 +173,7 @@ cdef class {{ name }}:
                 else:
                     raise Exception("not a valid value for enum {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }}")
             {%- elif field.type == 'string' %}
-                if type(value) == unicode:
+                if type(val) == unicode:
                     self._{{ field.name }}.append(str(val))
                 else:
                     self._{{ field.name }}.append(val)
@@ -201,7 +201,7 @@ cdef class {{ name }}:
             self._{{ field.name }} = value
             {%- endif %}
             {%- if field.type == 'message' %}
-            self._{{ field.name }}._SetListener(self)
+            self._{{ field.name }}._listener = <PyObject *>self
             {%- endif %}
         {%- endif %}
             if not self._is_present_in_parent:
@@ -333,7 +333,7 @@ cdef class {{ name }}:
             {%- if field.type != 'message' and field.modifier != 'repeated' %}
             self._{{ field.name }}_isSet = False
             {%- else %}
-            self._{{ field.name }}._SetListener(None)
+            self._{{ field.name }}._listener = <PyObject *>null_listener
             {%- endif -%}
             {%- if field.modifier == 'repeated' %}
                 {%- if field.type == 'message' %}
@@ -341,12 +341,12 @@ cdef class {{ name }}:
                 {%- elif field.type == 'string' %}
             self._{{ field.name }} = TypedList(str, self)
                 {%- else %}
-            self._{{ field.name }} = {{ field.list_type }}.__new__({{ field.list_type }}, message_listener=self)
+            self._{{ field.name }} = {{ field.list_type }}.__new__({{ field.list_type }}, listener=self)
                 {%- endif %}
             {%- elif field.type == 'message' %}
             self._{{ field.name }} = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}.__new__({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }})
             self._{{ field.name }}.reset()
-            self._{{ field.name }}._SetListener(self)
+            self._{{ field.name }}._listener = <PyObject *>self
             {%- elif field.default != None %}
                 {%- if field.type == 'string' %}
             self._{{ field.name }} = "{{ field.default }}"
@@ -640,12 +640,6 @@ cdef class {{ name }}:
         if not self._is_present_in_parent:
             self._is_present_in_parent = True
             (<object> self._listener)._Modified()
-
-    cpdef void _SetListener(self, listener):
-        if listener is None:
-            self._listener = <PyObject *>null_listener
-        else:
-            self._listener = <PyObject *>listener
 
     def SerializeToString(self):
         """

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -503,12 +503,6 @@ cdef class {{ name }}:
         """
         cdef int buf
         cdef bint already_present_in_parent = self._is_present_in_parent
-    {%- if message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
-        cdef int i
-    {%- endif %}
-    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
-        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_msg
-    {%- endfor %}
 
         if size is None:
             size = len(data)
@@ -523,27 +517,6 @@ cdef class {{ name }}:
 
         if not already_present_in_parent:
             self._Modified()
-
-    {% for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
-        {%- if field.type == 'message' %}
-        if not self._{{ field.name }}.IsInitialized():
-        {%- else %}
-        if not self._{{ field.name }}_isSet:
-        {%- endif %}
-            raise Exception("required field '{{ field.name }}' not initialized and does not have default")
-    {%- endfor %}
-
-    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'optional')|sort(attribute='index') %}
-        if self._{{ field.name }}._is_present_in_parent and not self._{{ field.name }}.IsInitialized():
-            raise Exception("Message {{ name }} is missing required field: {{ field.name }}")
-    {%- endfor %}
-
-    {%- for field in message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
-        for i in range(len(self._{{ field.name }})):
-            {{ field.name }}_msg = <{% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}>self._{{ field.name }}[i]
-            if not {{ field.name }}_msg.IsInitialized():
-                raise Exception("Message {{ name }} is missing required field: {{ field.name }}[%d]" % i)
-    {%- endfor %}
 
         return buf
 

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -21,6 +21,8 @@ cdef class {{ name }}:
 
     def __init__(self):
         self.reset()
+        self._is_present_in_parent = False
+        self._listener = None
         return
 
     def __str__(self):
@@ -50,14 +52,15 @@ cdef class {{ name }}:
         {%- endif -%}
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
-        self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }})
+        self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}, self)
             {%- elif field.type == 'string' %}
-        self._{{ field.name }} = TypedList(str)
+        self._{{ field.name }} = TypedList(str, self)
             {%- else %}
-        self._{{ field.name }} = {{ field.list_type }}()
+        self._{{ field.name }} = {{ field.list_type }}(message_listener=self)
             {%- endif %}
         {%- elif field.type == 'message' %}
         self._{{ field.name }} = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
+        self._{{ field.name }}._SetListener(self)
         {%- elif field.default != None %}
             {%- if field.type == 'string' %}
         self._{{ field.name }} = "{{ field.default }}"
@@ -73,7 +76,7 @@ cdef class {{ name }}:
         {%- else %}
         self._{{ field.name }} = 0
         {%- endif %}
-        {%- if field.modifier == 'required' and field.default == None %}
+        {%- if field.modifier != 'repeated' and field.type != 'message' %}
         self.__{{ field.name }}_set = 0
         {%- endif %}
     {%- endfor %}
@@ -87,14 +90,14 @@ cdef class {{ name }}:
         def __set__(self, value):
             {%- if field.type != 'message' and field.modifier != 'repeated' %}
             self._{{ field.name }}_isDefault = False
-            {%-endif -%}
+            {%- endif -%}
         {%- if field.modifier == 'repeated' %}
             {%- if field.type == 'message' %}
-            self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }})
+            self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}, self)
             {%- elif field.type == 'string' %}
-            self._{{ field.name }} = TypedList(str)
+            self._{{ field.name }} = TypedList(str, self)
             {%- else %}
-            self._{{ field.name }} = {{ field.list_type }}()
+            self._{{ field.name }} = {{ field.list_type }}(message_listener=self)
             {%- endif %}
             for val in value:
             {%- if field.type == 'enum' and field.enum_def != None %}
@@ -137,9 +140,11 @@ cdef class {{ name }}:
             self._{{ field.name }} = value
             {%- endif %}
         {%- endif %}
-        {%- if field.modifier == 'required' and field.default == None %}
+        {%- if field.modifier != 'repeated' and field.type != 'message' %}
             self.__{{ field.name }}_set = 1
         {%- endif %}
+            if not self._is_present_in_parent:
+                self._Modified()
     {% endfor %}
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size):
@@ -233,16 +238,146 @@ cdef class {{ name }}:
 
         {%- endif %}
 
-        {%- if field.modifier == 'required' and field.default == None %}
+        {%- if field.modifier != 'repeated' and field.type != 'message' %}
                 self.__{{ field.name }}_set = 1
         {%- endif %}
-
     {%- endfor %}
             else:
                 continue
     {%- endif %}
 
+        self._is_present_in_parent = True
+
         return current_offset
+
+    def Clear(self):
+        """Clears all data that was set in the message."""
+        self.reset()
+        self._Modified()
+
+    def ClearField(self, field_name):
+        """Clears the contents of a given field."""
+    {%- for field in message.fields|sort(attribute='index') %}
+        {%- if loop.index == 1 %}
+        if field_name == '{{ field.name }}':
+        {%- else %}
+        elif field_name == '{{ field.name }}':
+        {%- endif %}
+            {%- if field.type != 'message' and field.modifier != 'repeated' %}
+            self._{{ field.name }}_isDefault = True
+            {%- endif -%}
+            {%- if field.modifier == 'repeated' %}
+                {%- if field.type == 'message' %}
+            self._{{ field.name }} = TypedList({% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}, self)
+                {%- elif field.type == 'string' %}
+            self._{{ field.name }} = TypedList(str, self)
+                {%- else %}
+            self._{{ field.name }} = {{ field.list_type }}(message_listener=self)
+                {%- endif %}
+            {%- elif field.type == 'message' %}
+            self._{{ field.name }} = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
+            {%- elif field.default != None %}
+                {%- if field.type == 'string' %}
+            self._{{ field.name }} = "{{ field.default }}"
+                {%- elif field.type == 'enum' %}
+            self._{{ field.name }} = _{{ field.enum_default }}
+                {%- else %}
+            self._{{ field.name }} = {{ field.default }}
+                {%- endif %}
+            {%- elif field.type == 'string' %}
+            self._{{ field.name }} = ""
+            {%- elif field.type == 'enum' and field.enum_def != None %}
+            self._{{ field.name }} = _{{ field.enum_def.fields[0].name }}
+            {%- else %}
+            self._{{ field.name }} = 0
+            {%- endif %}
+            {%- if field.modifier != 'repeated' and field.type != 'message' %}
+            self.__{{ field.name }}_set = 0
+            {%- endif %}
+    {%- endfor %}
+
+        self._Modified()
+
+    def CopyFrom(self, other_msg):
+        """
+        Copies the content of the specified message into the current message.
+
+        Params:
+            other_msg: Message to copy into the current one.
+        """
+        if self is other_msg:
+            return
+        self.reset()
+        self.MergeFrom(other_msg)
+
+    def HasField(self, field_name):
+        """
+        Checks if a certain field is set for the message.
+        """
+    {%- for field in message.fields|rejectattr('modifier', 'equalto', 'repeated')|sort(attribute='index') %}
+        if field_name == '{{ field.name }}':
+        {%- if field.type == 'message' %}
+            return self._{{ field.name }}._is_present_in_parent
+        {%- else %}
+            return self.__{{ field.name }}_set != 0
+        {%- endif %}
+    {%- endfor %}
+        raise ValueError('Protocol message has no singular "%s" field.' % field_name)
+
+    def IsInitialized(self):
+        """
+        Checks if the message is initialized.
+
+        Returns:
+            bool: True if the message is initialized (i.e. all of its required
+                fields are set).
+        """
+    {%- for field in message.fields|selectattr('modifier', 'equalto', 'required')|selectattr('default', 'none')|sort(attribute='index') %}
+        {%- if field.type == 'message' %}
+        if not self._{{ field.name }}._is_present_in_parent:
+        {%- else %}
+        if self.__{{ field.name }}_set == 0:
+        {%- endif %}
+            return False
+    {%- endfor %}
+
+        return True
+
+    def MergeFrom(self, other_msg):
+        """
+        Merges the contents of the specified message into the current message.
+
+        Params:
+            other_msg: Message to merge into the current message.
+        """
+        if not isinstance(other_msg, {{ name }}):
+            raise TypeError(
+                "Parameter to MergeFrom() must be instance of same class: "
+                "expected %s got %s." % ('{{ name }}', type(other_msg).__name__))
+
+    {%- for field in message.fields|sort(attribute='index') %}
+        {%- if field.modifier == 'repeated' and field.type == 'message' %}
+        for {{ field.name }}_msg in other_msg.{{ field.name }}:
+            {{ field.name }}_elt = {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }}()
+            {{ field.name }}_elt.MergeFrom({{ field.name }}_msg)
+            self.{{ field.name }}.append({{ field.name }}_elt)
+        {%- elif field.modifier == 'repeated' %}
+        self._{{ field.name }}.extend(other_msg.{{ field.name }})
+        {%- elif field.type == 'message' %}
+        if other_msg.{{ field.name }}._is_present_in_parent:
+            self._{{ field.name }}.MergeFrom(other_msg.{{ field.name }})
+        {%- else %}
+        if other_msg.HasField('{{ field.name }}'):
+            {%- if field.type == 'enum' %}
+            self.{{ field.name }} = other_msg.{{ field.name }}
+            {%- else %}
+            self._{{ field.name }} = other_msg.{{ field.name }}
+            self.__{{ field.name }}_set = 1
+            {%- endif %}
+        {%- endif %}
+    {%- endfor %}
+
+        self._Modified()
 
     def ParseFromString(self, data, size=None, reset=True):
         """
@@ -269,10 +404,16 @@ cdef class {{ name }}:
 
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if field.modifier == 'required' and field.default == None %}
+            {%- if field.type == 'message' %}
+        if not self._{{field.name}}._is_present_in_parent:
+            {%- else %}
         if self.__{{ field.name }}_set == 0:
+            {%- endif %}
             raise Exception("required field '{{ field.name }}' not parsed and does not have default")
         {%- endif %}
     {%- endfor %}
+
+        self._Modified()
 
         return buf
 
@@ -394,6 +535,15 @@ cdef class {{ name }}:
         {%- endif %}
     {%- endfor %}
 
+    cpdef void _Modified(self):
+        if not self._is_present_in_parent:
+            self._is_present_in_parent = True
+            if self._listener is not None:
+                self._listener._Modified()
+
+    cpdef void _SetListener(self, listener):
+        self._listener = listener
+
     def SerializeToString(self):
         """
         Serialize the message class into a bytearray of protobuf encoded binary data.
@@ -403,7 +553,11 @@ cdef class {{ name }}:
         """
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if field.modifier == 'required' and field.default == None %}
+            {%- if field.type == 'message' %}
+        if not self._{{ field.name }}._is_present_in_parent:
+            {%- else %}
         if self.__{{ field.name }}_set == 0:
+            {%- endif %}
             raise Exception("required field '{{ field.name }}' not initialized and does not have default")
         {%- endif %}
     {%- endfor %}
@@ -467,10 +621,16 @@ cdef class {{ name }}:
 
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if field.modifier == 'required' and field.default == None %}
-        if self.__{{ field.name }}_set == False:
+            {%- if field.type == 'message' %}
+        if not self._{{ field.name }}._is_present_in_parent:
+            {%- else %}
+        if self.__{{ field.name }}_set == 0:
+            {%- endif %}
             raise Exception("required field '{{ field.name }}' not parsed and does not have default")
         {%- endif %}
     {%- endfor %}
+
+        self._Modified()
 
         return
 
@@ -485,7 +645,11 @@ cdef class {{ name }}:
 
     {%- for field in message.fields|sort(attribute='index') %}
         {%- if field.modifier == 'required' and field.default == None %}
-        if self.__{{ field.name }}_set == False:
+            {%- if field.type == 'message' %}
+        if not self._{{ field.name }}._is_present_in_parent:
+            {%- else %}
+        if self.__{{ field.name }}_set == 0:
+            {%- endif %}
             raise Exception("required field '{{ field.name }}' not initialized and does not have default")
         {%- endif %}
     {%- endfor %}

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
@@ -1,5 +1,10 @@
 from libc.stdint cimport *
 
+cdef class NullListener:
+    cpdef void _Modified(self)
+
+cdef public NullListener null_listener
+
 cdef class TypedList(list):
     
     cdef type _list_type

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
@@ -11,9 +11,8 @@ cdef public NullListener null_listener
 cdef class TypedList(list):
     
     cdef type _list_type
-    cdef PyObject *_message_listener
+    cdef PyObject *_listener
 
-    cpdef void _SetListener(self, listener)
 
 {% macro scalar_list(name, type) %}
 cdef class {{ name }}:
@@ -21,10 +20,9 @@ cdef class {{ name }}:
     cdef {{ type }} *_data
     cdef size_t _n_items
     cdef size_t _size
-    cdef PyObject *_message_listener
+    cdef PyObject *_listener
 
     cdef void _append(self, {{ type }} x)
-    cpdef void _SetListener(self, listener)
 
     cpdef append(self, {{ type }} x)
     cpdef extend(self, {{ name }} x)

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
@@ -1,14 +1,19 @@
 from libc.stdint cimport *
+from cpython.ref cimport PyObject
+
 
 cdef class NullListener:
     cpdef void _Modified(self)
 
 cdef public NullListener null_listener
 
+
 cdef class TypedList(list):
     
     cdef type _list_type
-    cdef object _message_listener
+    cdef PyObject *_message_listener
+
+    cpdef void _SetListener(self, listener)
 
 {% macro scalar_list(name, type) %}
 cdef class {{ name }}:
@@ -16,7 +21,9 @@ cdef class {{ name }}:
     cdef {{ type }} *_data
     cdef size_t _n_items
     cdef size_t _size
-    cdef object _message_listener
+    cdef PyObject *_message_listener
+
+    cpdef void _SetListener(self, listener)
 
     cpdef append(self, {{ type }} x)
     cpdef extend(self, {{ name }} x)

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
@@ -3,6 +3,7 @@ from libc.stdint cimport *
 cdef class TypedList(list):
     
     cdef type _list_type
+    cdef object _message_listener
 
 {% macro scalar_list(name, type) %}
 cdef class {{ name }}:
@@ -10,6 +11,7 @@ cdef class {{ name }}:
     cdef {{ type }} *_data
     cdef size_t _n_items
     cdef size_t _size
+    cdef object _message_listener
 
     cpdef append(self, {{ type }} x)
     cpdef extend(self, {{ name }} x)

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
@@ -23,6 +23,7 @@ cdef class {{ name }}:
     cdef size_t _size
     cdef PyObject *_message_listener
 
+    cdef void _append(self, {{ type }} x)
     cpdef void _SetListener(self, listener)
 
     cpdef append(self, {{ type }} x)

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
@@ -16,12 +16,12 @@ cdef public NullListener null_listener = NullListener()
 
 cdef class TypedList(list):
 
-    def __init__(self, type list_type, object message_listener=None):
+    def __init__(self, type list_type, object listener=None):
         self._list_type = list_type
-        if message_listener is None:
-            self._message_listener = <PyObject *>null_listener
+        if listener is None:
+            self._listener = <PyObject *>null_listener
         else:
-            self._message_listener = <PyObject *>message_listener
+            self._listener = <PyObject *>listener
 
     property list_type:
         def __get__(self):
@@ -34,7 +34,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setitem__(i, x)
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 
@@ -47,21 +47,15 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setslice__(i, j, x)
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 {%- endif %}
 
-    cpdef void _SetListener(self, listener):
-        if listener is None:
-            self._message_listener = <PyObject *>null_listener
-        else:
-            self._message_listener = <PyObject *>listener
-
     def add(self, **kwargs):
         elt = self._list_type(**kwargs)
         super(TypedList, self).append(elt)
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
         return elt
@@ -73,7 +67,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).append(x)
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 
@@ -85,7 +79,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).extend(x)
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 
@@ -96,7 +90,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).insert(i, x)
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 
@@ -104,14 +98,17 @@ cdef class TypedList(list):
 {% macro scalar_list(name, type) %}
 cdef class {{ name }}:
 
-    def __cinit__(self, size_t size=16, object message_listener=None):
+    def __cinit__(self, size_t size=16, object listener=None):
         self._data = <{{ type }} *>PyMem_Malloc(size * sizeof({{ type }}))
         if not self._data:
             raise MemoryError()
 
         self._n_items = 0
         self._size = size
-        self._SetListener(message_listener)
+        if listener is None:
+            self._listener = <PyObject *>null_listener
+        else:
+            self._listener = <PyObject *>listener
 
     def __dealloc__(self):
         PyMem_Free(self._data)
@@ -136,7 +133,7 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
 
         self._n_items -= 1
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 
@@ -169,22 +166,16 @@ cdef class {{ name }}:
             raise IndexError("list index out of range")
 
         self._data[i] = x
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 
     def __str__(self):
         return str(list(self))
 
-    cpdef void _SetListener(self, listener):
-        if listener is None:
-            self._message_listener = <PyObject *>null_listener
-        else:
-            self._message_listener = <PyObject *>listener
-
     cpdef append(self, {{ type }} x):
         self._append(x)
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 
@@ -207,7 +198,7 @@ cdef class {{ name }}:
             self._data[self._n_items + i] = x[i]
 
         if new_len != self._n_items:
-            listener = <object>self._message_listener
+            listener = <object>self._listener
             if not listener._is_present_in_parent:
                 listener._Modified()
         self._n_items = new_len
@@ -235,7 +226,7 @@ cdef class {{ name }}:
 
         self._data[i] = x
         self._n_items += 1
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 
@@ -244,7 +235,7 @@ cdef class {{ name }}:
             raise IndexError("pop from empty list")
 
         self._n_items -= 1
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
         return self._data[self._n_items]
@@ -266,7 +257,7 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
         
         self._n_items -= 1
-        listener = <object>self._message_listener
+        listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
 

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
@@ -3,8 +3,9 @@ from libc.stdint cimport *
 
 cdef class TypedList(list):
 
-    def __init__(self, type list_type):
+    def __init__(self, type list_type, object message_listener=None):
         self._list_type = list_type
+        self._message_listener = message_listener
 
     property list_type:
         def __get__(self):
@@ -17,6 +18,8 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setitem__(i, x)
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 
 {% if version_major != 3 %}
     def __setslice__(self, i, j, x):
@@ -27,11 +30,15 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setslice__(i, j, x)
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 {%- endif %}
 
     def add(self):
         elt = self._list_type()
         self.append(elt)
+        if self._message_listener is not None:
+            self._message_listener._Modified()
         return elt
 
     def append(self, x):
@@ -41,6 +48,8 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).append(x)
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 
     def extend(self, x):
         try:
@@ -50,6 +59,8 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).extend(x)
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 
     def insert(self, i, x):
         try:
@@ -58,18 +69,21 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).insert(i, x)
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 
 
 {% macro scalar_list(name, type) %}
 cdef class {{ name }}:
 
-    def __cinit__(self, size_t size=16):
+    def __cinit__(self, size_t size=16, object message_listener=None):
         self._data = <{{ type }} *>PyMem_Malloc(size * sizeof({{ type }}))
         if not self._data:
             raise MemoryError()
 
         self._n_items = 0
         self._size = size
+        self._message_listener = message_listener
 
     def __dealloc__(self):
         PyMem_Free(self._data)
@@ -94,6 +108,8 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
 
         self._n_items -= 1
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 
     def __getitem__(self, int i):
         if i < 0:
@@ -124,6 +140,8 @@ cdef class {{ name }}:
             raise IndexError("list index out of range")
 
         self._data[i] = x
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 
     def __str__(self):
         return str(list(self))
@@ -141,6 +159,8 @@ cdef class {{ name }}:
 
         self._data[self._n_items] = x
         self._n_items += 1
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 
     cpdef extend(self, {{ name }} x):
         cdef {{ type }} *mem
@@ -160,6 +180,8 @@ cdef class {{ name }}:
         for i in range(len(x)):
             self._data[self._n_items + i] = x[i]
 
+        if new_len != self._n_items and self._message_listener is not None:
+            self._message_listener._Modified()
         self._n_items = new_len
 
     cpdef insert(self, int i, {{ type }} x):
@@ -185,12 +207,16 @@ cdef class {{ name }}:
 
         self._data[i] = x
         self._n_items += 1
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 
     cpdef pop(self):
         if self._n_items == 0:
             raise IndexError("pop from empty list")
 
         self._n_items -= 1
+        if self._message_listener is not None:
+            self._message_listener._Modified()
         return self._data[self._n_items]
 
     cpdef remove(self, {{ type }} x):
@@ -210,6 +236,8 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
         
         self._n_items -= 1
+        if self._message_listener is not None:
+            self._message_listener._Modified()
 {% endmacro %}
 
 {% for name, type in def.items() %}

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
@@ -1,11 +1,21 @@
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from libc.stdint cimport *
 
+import weakref
+
+
+cdef class NullListener:
+    cpdef void _Modified(self):
+        return
+
+cdef public NullListener null_listener = NullListener()
+
+
 cdef class TypedList(list):
 
     def __init__(self, type list_type, object message_listener=None):
         self._list_type = list_type
-        self._message_listener = message_listener
+        self._message_listener = null_listener if message_listener is None else weakref.proxy(message_listener)
 
     property list_type:
         def __get__(self):
@@ -18,8 +28,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setitem__(i, x)
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 
 {% if version_major != 3 %}
     def __setslice__(self, i, j, x):
@@ -30,15 +39,13 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setslice__(i, j, x)
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 {%- endif %}
 
     def add(self):
         elt = self._list_type()
         self.append(elt)
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
         return elt
 
     def append(self, x):
@@ -48,8 +55,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).append(x)
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 
     def extend(self, x):
         try:
@@ -59,8 +65,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).extend(x)
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 
     def insert(self, i, x):
         try:
@@ -69,8 +74,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).insert(i, x)
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 
 
 {% macro scalar_list(name, type) %}
@@ -83,7 +87,7 @@ cdef class {{ name }}:
 
         self._n_items = 0
         self._size = size
-        self._message_listener = message_listener
+        self._message_listener = null_listener if message_listener is None else weakref.proxy(message_listener)
 
     def __dealloc__(self):
         PyMem_Free(self._data)
@@ -108,8 +112,7 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
 
         self._n_items -= 1
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 
     def __getitem__(self, int i):
         if i < 0:
@@ -140,8 +143,7 @@ cdef class {{ name }}:
             raise IndexError("list index out of range")
 
         self._data[i] = x
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 
     def __str__(self):
         return str(list(self))
@@ -159,8 +161,7 @@ cdef class {{ name }}:
 
         self._data[self._n_items] = x
         self._n_items += 1
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 
     cpdef extend(self, {{ name }} x):
         cdef {{ type }} *mem
@@ -180,7 +181,7 @@ cdef class {{ name }}:
         for i in range(len(x)):
             self._data[self._n_items + i] = x[i]
 
-        if new_len != self._n_items and self._message_listener is not None:
+        if new_len != self._n_items:
             self._message_listener._Modified()
         self._n_items = new_len
 
@@ -207,16 +208,14 @@ cdef class {{ name }}:
 
         self._data[i] = x
         self._n_items += 1
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 
     cpdef pop(self):
         if self._n_items == 0:
             raise IndexError("pop from empty list")
 
         self._n_items -= 1
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
         return self._data[self._n_items]
 
     cpdef remove(self, {{ type }} x):
@@ -236,8 +235,7 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
         
         self._n_items -= 1
-        if self._message_listener is not None:
-            self._message_listener._Modified()
+        self._message_listener._Modified()
 {% endmacro %}
 
 {% for name, type in def.items() %}

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
@@ -1,7 +1,6 @@
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from libc.stdint cimport *
-
-import weakref
+from cpython.ref cimport PyObject
 
 
 cdef class NullListener:
@@ -15,7 +14,7 @@ cdef class TypedList(list):
 
     def __init__(self, type list_type, object message_listener=None):
         self._list_type = list_type
-        self._message_listener = null_listener if message_listener is None else weakref.proxy(message_listener)
+        self._SetListener(message_listener)
 
     property list_type:
         def __get__(self):
@@ -28,7 +27,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setitem__(i, x)
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 
 {% if version_major != 3 %}
     def __setslice__(self, i, j, x):
@@ -39,13 +38,19 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setslice__(i, j, x)
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 {%- endif %}
+
+    cpdef void _SetListener(self, listener):
+        if listener is None:
+            self._message_listener = <PyObject *>null_listener
+        else:
+            self._message_listener = <PyObject *>listener
 
     def add(self):
         elt = self._list_type()
-        self.append(elt)
-        self._message_listener._Modified()
+        super(TypedList, self).append(elt)
+        (<object>self._message_listener)._Modified()
         return elt
 
     def append(self, x):
@@ -55,7 +60,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).append(x)
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 
     def extend(self, x):
         try:
@@ -65,7 +70,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).extend(x)
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 
     def insert(self, i, x):
         try:
@@ -74,7 +79,7 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).insert(i, x)
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 
 
 {% macro scalar_list(name, type) %}
@@ -87,7 +92,7 @@ cdef class {{ name }}:
 
         self._n_items = 0
         self._size = size
-        self._message_listener = null_listener if message_listener is None else weakref.proxy(message_listener)
+        self._SetListener(message_listener)
 
     def __dealloc__(self):
         PyMem_Free(self._data)
@@ -112,7 +117,7 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
 
         self._n_items -= 1
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 
     def __getitem__(self, int i):
         if i < 0:
@@ -143,10 +148,16 @@ cdef class {{ name }}:
             raise IndexError("list index out of range")
 
         self._data[i] = x
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 
     def __str__(self):
         return str(list(self))
+
+    cpdef void _SetListener(self, listener):
+        if listener is None:
+            self._message_listener = <PyObject *>null_listener
+        else:
+            self._message_listener = <PyObject *>listener
 
     cpdef append(self, {{ type }} x):
         cdef {{ type }} *mem
@@ -161,7 +172,7 @@ cdef class {{ name }}:
 
         self._data[self._n_items] = x
         self._n_items += 1
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 
     cpdef extend(self, {{ name }} x):
         cdef {{ type }} *mem
@@ -182,7 +193,7 @@ cdef class {{ name }}:
             self._data[self._n_items + i] = x[i]
 
         if new_len != self._n_items:
-            self._message_listener._Modified()
+            (<object>self._message_listener)._Modified()
         self._n_items = new_len
 
     cpdef insert(self, int i, {{ type }} x):
@@ -208,14 +219,14 @@ cdef class {{ name }}:
 
         self._data[i] = x
         self._n_items += 1
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 
     cpdef pop(self):
         if self._n_items == 0:
             raise IndexError("pop from empty list")
 
         self._n_items -= 1
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
         return self._data[self._n_items]
 
     cpdef remove(self, {{ type }} x):
@@ -235,7 +246,7 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
         
         self._n_items -= 1
-        self._message_listener._Modified()
+        (<object>self._message_listener)._Modified()
 {% endmacro %}
 
 {% for name, type in def.items() %}

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
@@ -4,6 +4,10 @@ from cpython.ref cimport PyObject
 
 
 cdef class NullListener:
+    property _is_present_in_parent:
+        def __get__(self):
+            return True
+
     cpdef void _Modified(self):
         return
 
@@ -14,7 +18,10 @@ cdef class TypedList(list):
 
     def __init__(self, type list_type, object message_listener=None):
         self._list_type = list_type
-        self._SetListener(message_listener)
+        if message_listener is None:
+            self._message_listener = <PyObject *>null_listener
+        else:
+            self._message_listener = <PyObject *>message_listener
 
     property list_type:
         def __get__(self):
@@ -27,7 +34,9 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setitem__(i, x)
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
 {% if version_major != 3 %}
     def __setslice__(self, i, j, x):
@@ -38,7 +47,9 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).__setslice__(i, j, x)
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 {%- endif %}
 
     cpdef void _SetListener(self, listener):
@@ -47,10 +58,12 @@ cdef class TypedList(list):
         else:
             self._message_listener = <PyObject *>listener
 
-    def add(self):
-        elt = self._list_type()
+    def add(self, **kwargs):
+        elt = self._list_type(**kwargs)
         super(TypedList, self).append(elt)
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
         return elt
 
     def append(self, x):
@@ -60,7 +73,9 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).append(x)
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
     def extend(self, x):
         try:
@@ -70,7 +85,9 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).extend(x)
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
     def insert(self, i, x):
         try:
@@ -79,7 +96,9 @@ cdef class TypedList(list):
             raise Exception("type mismatch")
 
         super(TypedList, self).insert(i, x)
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
 
 {% macro scalar_list(name, type) %}
@@ -117,7 +136,9 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
 
         self._n_items -= 1
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
     def __getitem__(self, int i):
         if i < 0:
@@ -148,7 +169,9 @@ cdef class {{ name }}:
             raise IndexError("list index out of range")
 
         self._data[i] = x
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
     def __str__(self):
         return str(list(self))
@@ -160,19 +183,10 @@ cdef class {{ name }}:
             self._message_listener = <PyObject *>listener
 
     cpdef append(self, {{ type }} x):
-        cdef {{ type }} *mem
-
-        if self._n_items == self._size:
-            mem = <{{ type }} *>PyMem_Realloc(self._data, 2 * self._size * sizeof({{ type }}))
-            if not mem:
-                raise MemoryError()
-
-            self._data = mem
-            self._size *= 2
-
-        self._data[self._n_items] = x
-        self._n_items += 1
-        (<object>self._message_listener)._Modified()
+        self._append(x)
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
     cpdef extend(self, {{ name }} x):
         cdef {{ type }} *mem
@@ -193,7 +207,9 @@ cdef class {{ name }}:
             self._data[self._n_items + i] = x[i]
 
         if new_len != self._n_items:
-            (<object>self._message_listener)._Modified()
+            listener = <object>self._message_listener
+            if not listener._is_present_in_parent:
+                listener._Modified()
         self._n_items = new_len
 
     cpdef insert(self, int i, {{ type }} x):
@@ -219,14 +235,18 @@ cdef class {{ name }}:
 
         self._data[i] = x
         self._n_items += 1
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
     cpdef pop(self):
         if self._n_items == 0:
             raise IndexError("pop from empty list")
 
         self._n_items -= 1
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
         return self._data[self._n_items]
 
     cpdef remove(self, {{ type }} x):
@@ -246,7 +266,23 @@ cdef class {{ name }}:
             self._data[j] = self._data[j + 1]
         
         self._n_items -= 1
-        (<object>self._message_listener)._Modified()
+        listener = <object>self._message_listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
+
+    cdef void _append(self, {{ type }} x):
+        cdef {{ type }} *mem
+
+        if self._n_items == self._size:
+            mem = <{{ type }} *>PyMem_Realloc(self._data, 2 * self._size * sizeof({{ type }}))
+            if not mem:
+                raise MemoryError()
+
+            self._data = mem
+            self._size *= 2
+
+        self._data[self._n_items] = x
+        self._n_items += 1
 {% endmacro %}
 
 {% for name, type in def.items() %}

--- a/tests/proto/test_is_initialized.proto
+++ b/tests/proto/test_is_initialized.proto
@@ -1,0 +1,14 @@
+message SubMessage {
+    required int32 req_field = 1;
+    optional int32 opt_field = 2;
+}
+
+message TestIsInitialized {
+    required int32 req_field = 1;
+    optional SubMessage sub_message = 2;
+    repeated SubMessage list_sub = 3;
+}
+
+message TestWithRequiredSubMessage {
+    required SubMessage req_sub = 1;
+}

--- a/tests/proto/test_message_field_types.proto
+++ b/tests/proto/test_message_field_types.proto
@@ -1,0 +1,10 @@
+message TestFieldTypes {
+    // Tests for fields of the bytes type
+    optional bytes payload = 1;
+    optional bytes payload_with_default = 2 [default = 'Hello World'];
+
+    // Tests for packed repeated fields and repeated bytes type fields
+    repeated int32 packed_var_width_list = 3 [packed=true];
+    repeated sfixed32 packed_fixed_width_list = 4 [packed=true];
+    repeated bytes list_bytes = 5;
+}

--- a/tests/test_has_field.py
+++ b/tests/test_has_field.py
@@ -1,0 +1,112 @@
+import os
+import sys
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, 'build')
+
+
+Test = None
+TestRef = None
+TestSs1 = None
+TestSs1Thing = None
+
+
+class HasFieldTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
+                                   if name.startswith('lib')].pop())
+
+        if lib not in sys.path:
+            sys.path.insert(0, lib)
+
+        global Test, TestRef, TestSs1, TestSs1Thing
+        from test_message_proto import Test, TestSs1, TestSs1Thing
+        from test_ref_message_proto import TestRef
+
+    def test_has_field_for_repeated_field_raises_value_error(self):
+        message = Test()
+        self.assertRaises(ValueError, message.HasField, 'list_fieldx')
+
+    def test_has_field_for_unset_scalar_field_returns_false(self):
+        message = Test()
+        self.assertFalse(message.HasField('timestamp'))
+
+    def test_has_field_for_set_scalar_field_returns_true(self):
+        message = Test()
+        message.timestamp = 123
+        self.assertTrue(message.HasField('timestamp'))
+
+    def test_has_field_for_cleared_scalar_field_returns_false(self):
+        message = Test()
+        message.timestamp = 123
+        message.ClearField('timestamp')
+        self.assertFalse(message.HasField('timestamp'))
+
+    def test_has_field_for_unset_message_field_returns_false(self):
+        message = Test()
+        self.assertFalse(message.HasField('substruct'))
+
+    def test_has_field_for_set_message_field_returns_true(self):
+        message = Test()
+        message.substruct.field2 = "something"
+        self.assertTrue(message.HasField('substruct'))
+
+    def test_has_field_for_cleared_message_field_returns_false(self):
+        message = Test()
+        message.substruct.field2 = "something"
+        message.ClearField('substruct')
+        self.assertFalse(message.HasField('substruct'))
+
+    def test_has_field_for_scalar_field_of_cleared_message_returns_false(self):
+        message = Test()
+        message.timestamp = 123
+        message.Clear()
+        self.assertFalse(message.HasField('timestamp'))
+
+    def test_has_field_for_message_field_of_cleared_message_returns_false(self):
+        message = Test()
+        message.substruct.field2 = "something"
+        message.Clear()
+        self.assertFalse(message.HasField('substruct'))
+
+    def test_has_field_for_indirectly_set_message_field_returns_true(self):
+        message = Test()
+        message.substruct.field3.field1 = 3.14159
+        self.assertTrue(message.HasField('substruct'))
+
+    def test_has_field_for_cleared_indirectly_set_message_field_returns_false(self):
+        message = Test()
+        message.substruct.field3.field1 = 3.14159
+        message.ClearField('substruct')
+        self.assertFalse(message.HasField('substruct'))
+
+    def test_has_field_for_message_field_set_by_repeated_field_returns_true(self):
+        message = Test()
+        message.substruct.list.append(3)
+        self.assertTrue(message.HasField('substruct'))
+
+    def test_has_field_for_message_field_set_by_repeated_message_field_returns_true(self):
+        message = Test()
+        message.substruct.list_object.append(TestSs1Thing())
+        self.assertTrue(message.HasField('substruct'))
+
+    def test_has_field_for_string_field_set_by_deserialization_returns_true(self):
+        ref_message = TestRef()
+        ref_message.field3 = "Hello World"
+        ref_message2 = TestRef.FromString(ref_message.SerializeToString())
+        self.assertTrue(ref_message2.HasField('field3'))
+
+    def test_has_field_for_scalar_field_set_by_deserialization_returns_true(self):
+        ref_message = TestRef()
+        ref_message.field1 = 1
+        ref_message2 = TestRef.FromString(ref_message.SerializeToString())
+        self.assertTrue(ref_message2.HasField('field1'))
+
+    def test_has_field_for_message_field_set_by_deserialization_returns_true(self):
+        ss1_message = TestSs1()
+        ss1_message.field3.field1 = 3.14159
+        ss1_message2 = TestSs1.FromString(ss1_message.SerializeToString())
+        self.assertTrue(ss1_message2.field3._is_present_in_parent)

--- a/tests/test_is_initialized.py
+++ b/tests/test_is_initialized.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, 'build')
+
+
+TestIsInitialized = None
+SubMessage = None
+TestWithRequiredSubMessage = None
+
+
+class MergeFromTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
+                                   if name.startswith('lib')].pop())
+
+        if lib not in sys.path:
+            sys.path.insert(0, lib)
+
+        global TestIsInitialized, SubMessage, TestWithRequiredSubMessage
+        from test_is_initialized_proto import TestIsInitialized, SubMessage, TestWithRequiredSubMessage
+
+    def test_new_message_is_not_initialized(self):
+        message = TestIsInitialized()
+        self.assertFalse(message.IsInitialized())
+
+    def test_message_with_all_required_fields_set_is_initialized(self):
+        message = TestIsInitialized()
+        message.req_field = 1
+        self.assertTrue(message.IsInitialized())
+
+    def test_new_message_with_required_submessage_is_not_initialized(self):
+        message = TestWithRequiredSubMessage()
+        self.assertFalse(message.IsInitialized())
+
+    def test_message_with_initialized_required_submessage_is_initialized(self):
+        message = TestWithRequiredSubMessage()
+        message.req_sub.req_field = 1
+        self.assertTrue(message.IsInitialized())
+
+    def test_message_with_uninitialized_submessage_is_not_initialized(self):
+        message = TestIsInitialized()
+        message.req_field = 1
+        message.sub_message.opt_field = 2
+        self.assertFalse(message.IsInitialized())
+
+    def test_message_with_initialized_submessage_is_initialized(self):
+        message = TestIsInitialized()
+        message.req_field = 1
+        message.sub_message.req_field = 2
+        self.assertTrue(message.IsInitialized())
+
+    def test_message_with_uninitialized_repeated_submessage_is_not_initialized(self):
+        message = TestIsInitialized()
+        message.req_field = 1
+        message.list_sub.add().opt_field = 2
+        self.assertFalse(message.IsInitialized())
+
+    def test_message_with_initialized_repeated_submessage_is_initialized(self):
+        message = TestIsInitialized()
+        message.req_field = 1
+        message.list_sub.add().req_field = 2
+        self.assertTrue(message.IsInitialized())

--- a/tests/test_merge_from.py
+++ b/tests/test_merge_from.py
@@ -1,0 +1,141 @@
+import os
+import sys
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, 'build')
+
+
+Test = None
+TestSs1 = None
+TestSs3 = None
+
+
+class MergeFromTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
+                                   if name.startswith('lib')].pop())
+
+        if lib not in sys.path:
+            sys.path.insert(0, lib)
+
+        global Test, TestSs1, TestSs3
+        from test_message_proto import Test, TestSs1, TestSs3
+
+    def test_merge_from_wrong_type_raises_type_error(self):
+        dest = Test()
+        self.assertRaises(TypeError, dest.MergeFrom, 1)
+
+    def test_merge_from_empty_message_notifies_parent(self):
+        source = TestSs1()
+        dest = Test()
+        dest.substruct.MergeFrom(source)
+        self.assertTrue(dest.HasField('substruct'))
+
+    def test_merge_from_empty_message_does_not_set_scalar_field(self):
+        source = TestSs3()
+        dest = TestSs3()
+        dest.MergeFrom(source)
+        self.assertFalse(dest.HasField('int_field'))
+
+    def test_merge_from_empty_message_does_not_set_enum_field(self):
+        source = Test()
+        dest = Test()
+        dest.MergeFrom(source)
+        self.assertFalse(dest.HasField('enum_field'))
+
+    def test_merge_from_empty_message_does_not_set_message_field(self):
+        source = TestSs3()
+        dest = TestSs3()
+        dest.MergeFrom(source)
+        self.assertFalse(dest.HasField('substruct_ref'))
+
+    def test_merge_from_does_set_scalar_field_that_is_set_in_source(self):
+        source = TestSs3()
+        dest = TestSs3()
+        source.int_field = 3
+        dest.MergeFrom(source)
+        self.assertEqual(dest.int_field, 3)
+
+    def test_merge_from_does_set_enum_field_that_is_set_in_source(self):
+        source = Test()
+        dest = Test()
+        source.enum_field = Test.TEST_ENUM_FIELD_2
+        dest.MergeFrom(source)
+        self.assertEqual(dest.enum_field, Test.TEST_ENUM_FIELD_2)
+
+    def test_merge_from_does_merge_message_field_that_is_set_in_source(self):
+        source = TestSs3()
+        dest = TestSs3()
+        source.substruct_ref.timestamp = 123
+        dest.MergeFrom(source)
+        self.assertEqual(dest.substruct_ref.timestamp, 123)
+
+    def test_merge_from_does_not_set_field_that_is_not_set_in_source(self):
+        source = TestSs3()
+        dest = TestSs3()
+        source.int_field = 3
+        dest.MergeFrom(source)
+        self.assertFalse(dest.HasField('another_int_field'))
+
+    def test_merge_from_does_not_modify_field_that_is_not_set_in_source(self):
+        source = TestSs3()
+        dest = TestSs3()
+        source.int_field = 3
+        dest.another_int_field = 5
+        dest.MergeFrom(source)
+        self.assertEqual(dest.another_int_field, 5)
+
+    def test_merge_from_overwrites_scalar_field_that_is_set_in_source(self):
+        source = TestSs3()
+        dest = TestSs3()
+        source.int_field = 5
+        dest.int_field = 3
+        dest.MergeFrom(source)
+        self.assertEqual(dest.int_field, 5)
+
+    def test_merge_from_overwrites_message_field_that_is_set_in_source(self):
+        source = TestSs3()
+        dest = TestSs3()
+        source.substruct_ref.timestamp = 123
+        dest.substruct_ref.timestamp = 456
+        dest.MergeFrom(source)
+        self.assertEqual(dest.substruct_ref.timestamp, 123)
+
+    def test_merge_from_sets_repeated_scalar_field_that_is_set_in_source(self):
+        source = Test()
+        dest = Test()
+        source.list_fieldx.append(3)
+        dest.MergeFrom(source)
+        self.assertEqual(len(dest.list_fieldx), 1)
+        self.assertEqual(dest.list_fieldx[0], 3)
+
+    def test_merge_from_extends_repeated_scalar_field_that_is_set_in_source(self):
+        source = Test()
+        dest = Test()
+        source.list_fieldx.append(3)
+        dest.list_fieldx.append(4)
+        dest.MergeFrom(source)
+        self.assertEqual(len(dest.list_fieldx), 2)
+        self.assertEqual(dest.list_fieldx[0], 4)
+        self.assertEqual(dest.list_fieldx[1], 3)
+
+    def test_merge_from_sets_repeated_message_field_that_is_set_in_source(self):
+        source = Test()
+        dest = Test()
+        source.list_ref.add().field1 = 3
+        dest.MergeFrom(source)
+        self.assertEqual(len(dest.list_ref), 1)
+        self.assertEqual(dest.list_ref[0].field1, 3)
+
+    def test_merge_from_extends_repeated_message_field_that_is_set_in_source(self):
+        source = Test()
+        dest = Test()
+        source.list_ref.add().field1 = 3
+        dest.list_ref.add().field1 = 4
+        dest.MergeFrom(source)
+        self.assertEqual(len(dest.list_ref), 2)
+        self.assertEqual(dest.list_ref[0].field1, 4)
+        self.assertEqual(dest.list_ref[1].field1, 3)

--- a/tests/test_merge_from.py
+++ b/tests/test_merge_from.py
@@ -2,6 +2,8 @@ import os
 import sys
 import unittest
 
+import messages.test_message_pb2 as google_test
+
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 BUILD = os.path.join(HERE, 'build')
@@ -139,3 +141,12 @@ class MergeFromTest(unittest.TestCase):
         self.assertEqual(len(dest.list_ref), 2)
         self.assertEqual(dest.list_ref[0].field1, 4)
         self.assertEqual(dest.list_ref[1].field1, 3)
+
+    def test_merge_from_with_google_protobuf_message_instance_is_successful(self):
+        source = google_test.Test.Ss3()
+        source.int_field = 3
+        source.substruct_ref.timestamp = 12345
+        dest = TestSs3()
+        dest.MergeFrom(source)
+        self.assertEqual(dest.int_field, 3)
+        self.assertEqual(dest.substruct_ref.timestamp, 12345)

--- a/tests/test_merge_from.py
+++ b/tests/test_merge_from.py
@@ -141,12 +141,3 @@ class MergeFromTest(unittest.TestCase):
         self.assertEqual(len(dest.list_ref), 2)
         self.assertEqual(dest.list_ref[0].field1, 4)
         self.assertEqual(dest.list_ref[1].field1, 3)
-
-    def test_merge_from_with_google_protobuf_message_instance_is_successful(self):
-        source = google_test.Test.Ss3()
-        source.int_field = 3
-        source.substruct_ref.timestamp = 12345
-        dest = TestSs3()
-        dest.MergeFrom(source)
-        self.assertEqual(dest.int_field, 3)
-        self.assertEqual(dest.substruct_ref.timestamp, 12345)

--- a/tests/test_message_field_types.py
+++ b/tests/test_message_field_types.py
@@ -1,0 +1,94 @@
+import os
+import sys
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, 'build')
+
+
+TestFieldTypes = None
+
+
+class MergeFromTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
+                                   if name.startswith('lib')].pop())
+
+        if lib not in sys.path:
+            sys.path.insert(0, lib)
+
+        global TestFieldTypes
+        from test_message_field_types_proto import TestFieldTypes
+
+    def test_bytes_payload_serialize_to_string(self):
+        message = TestFieldTypes()
+        message.payload = b'\x01\x02\x03'
+        self.assertEqual(message.SerializeToString(), '\n\x03\x01\x02\x03')
+
+    def test_bytes_payload_parse_from_string(self):
+        message = TestFieldTypes()
+        message.ParseFromString('\n\x03\x01\x02\x03')
+        self.assertEqual(message.payload, '\x01\x02\x03')
+
+    def test_uninitialized_message_serialize_to_json(self):
+        message = TestFieldTypes()
+        self.assertEqual(message.SerializeToJson(), '{}')
+
+    def test_bytes_payload_serialize_to_json(self):
+        message = TestFieldTypes()
+        message.payload = b'\x01\x02\x03'
+        self.assertEqual(message.SerializeToJson(), '{"payload": "\\u0001\\u0002\\u0003"}')
+
+    def test_bytes_payload_parse_from_json(self):
+        message = TestFieldTypes()
+        message.ParseFromJson('{"payload": "\\u0001\\u0002\\u0003"}')
+        self.assertEqual(message.payload, '\x01\x02\x03')
+
+    def test_bytes_payload_with_default_has_default_value(self):
+        message = TestFieldTypes()
+        self.assertEqual(message.payload_with_default, 'Hello World')
+
+    def test_packed_var_width_list_serialize_to_string(self):
+        message = TestFieldTypes()
+        message.packed_var_width_list.append(1)
+        message.packed_var_width_list.append(-2)
+        message.packed_var_width_list.append(3)
+        self.assertEqual(message.SerializeToString(), '\x1a\x0c\x01\xfe\xff\xff\xff\xff\xff\xff\xff\xff\x01\x03')
+
+    def test_packed_var_width_list_parse_from_string(self):
+        message = TestFieldTypes()
+        message.ParseFromString('\x1a\x0c\x01\xfe\xff\xff\xff\xff\xff\xff\xff\xff\x01\x03')
+        self.assertEqual(len(message.packed_var_width_list), 3)
+        self.assertEqual(message.packed_var_width_list[0], 1)
+        self.assertEqual(message.packed_var_width_list[1], -2)
+        self.assertEqual(message.packed_var_width_list[2], 3)
+
+    def test_packed_fixed_width_list_serialize_to_string(self):
+        message = TestFieldTypes()
+        message.packed_fixed_width_list.append(1)
+        message.packed_fixed_width_list.append(-2)
+        message.packed_fixed_width_list.append(3)
+        self.assertEqual(message.SerializeToString(), '"\x0c\x01\x00\x00\x00\xfe\xff\xff\xff\x03\x00\x00\x00')
+
+    def test_packed_fixed_width_list_parse_from_string(self):
+        message = TestFieldTypes()
+        message.ParseFromString('"\x0c\x01\x00\x00\x00\xfe\xff\xff\xff\x03\x00\x00\x00')
+        self.assertEqual(len(message.packed_fixed_width_list), 3)
+        self.assertEqual(message.packed_fixed_width_list[0], 1)
+        self.assertEqual(message.packed_fixed_width_list[1], -2)
+        self.assertEqual(message.packed_fixed_width_list[2], 3)
+
+    def test_list_bytes_serialize_to_string(self):
+        message = TestFieldTypes()
+        message.list_bytes.append('Et')
+        message.list_bytes.append('tu,')
+        message.list_bytes.append('Brute?')
+        self.assertEqual(message.SerializeToString(), '*\x02Et*\x03tu,*\x06Brute?')
+
+    def test_list_bytes_parse_from_string(self):
+        message = TestFieldTypes()
+        message.ParseFromString('*\x02Et*\x03tu,*\x06Brute?')
+        self.assertEqual(len(message.list_bytes), 3)
+        self.assertEqual(message.list_bytes, ['Et', 'tu,', 'Brute?'])

--- a/tests/test_message_init_kwargs.py
+++ b/tests/test_message_init_kwargs.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, 'build')
+
+
+Test = None
+TestSs1 = None
+TestSs3 = None
+
+
+class MergeFromTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
+                                   if name.startswith('lib')].pop())
+
+        if lib not in sys.path:
+            sys.path.insert(0, lib)
+
+        global Test, TestSs1, TestSs3
+        from test_message_proto import Test, TestSs1, TestSs3
+
+    def test_message_init_with_bad_keyword_arg_raises_value_error(self):
+        self.assertRaises(ValueError, Test, non_existant=3)
+
+    def test_message_init_with_scalar_field_keyword_arg_sets_value(self):
+        message = Test(req_field=3)
+        self.assertEqual(message.req_field, 3)
+
+    def test_message_init_with_message_field_keyword_arg_merges(self):
+        ss3_message = TestSs3()
+        ss3_message.int_field = 7
+        message = Test(another_substruct=ss3_message)
+        self.assertFalse(message.another_substruct is ss3_message)
+        self.assertEqual(message.another_substruct.int_field, 7)
+
+    def test_message_init_with_repeated_scalar_field_keyword_arg_extends(self):
+        source_message = Test()
+        source_message.list_fieldx.append(7)
+        source_message.list_fieldx.append(8)
+        source_message.list_fieldx.append(9)
+        message = Test(list_fieldx=source_message.list_fieldx)
+        self.assertEqual(list(message.list_fieldx), [7, 8, 9])
+
+    def test_message_init_with_repeated_message_field_keyword_arg_extends(self):
+        source_message = Test()
+        source_message.list_ref.add().timestamp = 123
+        source_message.list_ref.add().timestamp = 456
+        message = Test(list_ref=source_message.list_ref)
+        self.assertEqual(message.list_ref[0].timestamp, 123)
+        self.assertEqual(message.list_ref[1].timestamp, 456)
+
+    def test_message_init_by_repeated_field_add_method_passes_keyword_args(self):
+        message = Test()
+        message.list_ref.add(timestamp=123, field1=456)
+        self.assertEqual(message.list_ref[0].timestamp, 123)
+        self.assertEqual(message.list_ref[0].field1, 456)


### PR DESCRIPTION
This PR addresses issue #16 and adds support for the following message methods:

- `Clear`
- `ClearField`
- `CopyFrom`
- `HasField`
- `IsInitialized`
- `MergeFrom`
- `MergeFromString`
- `SetInParent`
- `SerializePartialToString`

I have removed message validation from `ParseFromString` as it is not performed in protobuf's `ParseFromString` method. Also, message constructors and the `TypedList.add` method now support keyword arguments as protobuf's equivalents do.

Finally, this PR should also fix issue #8.