### PR TITLE
Use setup_requires for Jinja2 and Cython.

### DIFF
--- a/pyrobuf/setuptools_ext.py
+++ b/pyrobuf/setuptools_ext.py
@@ -1,0 +1,57 @@
+"""Setuptools integration."""
+import glob
+import os
+
+from Cython.Build import cythonize
+from jinja2 import Environment, PackageLoader
+from pyrobuf.__main__ import generate, HERE
+from pyrobuf.parse_proto import Parser
+
+try:
+    basestring
+except NameError:
+    # Python 3.x
+    basestring = str
+
+
+def add_pyrobuf_module(dist, pyrobuf_module):
+    parser = Parser()
+
+    env = Environment(loader=PackageLoader('pyrobuf.protobuf', 'templates'))
+    templ_pxd = env.get_template('proto_pxd.tmpl')
+    templ_pyx = env.get_template('proto_pyx.tmpl')
+
+    dir_name = "pyrobuf/_" + pyrobuf_module
+
+    os.makedirs(dir_name, exist_ok=True)
+
+    if os.path.isdir(pyrobuf_module):
+        for spec in glob.glob(os.path.join(pyrobuf_module, '*.proto')):
+            generate(spec, dir_name, parser, templ_pxd, templ_pyx)
+
+        _, name = os.path.split(pyrobuf_module)
+        pyx = os.path.join(dir_name, '*.pyx')
+
+    else:
+        name, _ = os.path.splitext(os.path.basename(pyrobuf_module))
+        if not name:
+            print("not a .proto file")
+            return
+
+        generate(pyrobuf_module, dir_name, parser, templ_pxd, templ_pyx)
+
+        pyx = os.path.join(dir_name, "%s_proto.pyx" % name)
+
+    if dist.ext_modules is None:
+        dist.ext_modules = []
+    dist.ext_modules.extend(cythonize([pyx],
+                            include_path=[os.path.join(HERE, 'src'), dir_name]))
+
+
+def pyrobuf_modules(dist, attr, value):
+    assert attr == 'pyrobuf_modules'
+    if isinstance(value, basestring):
+        value = [value]
+
+    for pyrobuf_module in value:
+        add_pyrobuf_module(dist, pyrobuf_module)

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,6 @@ setup(
     long_description=open(os.path.join(HERE, 'README.md')).read(),
     url='https://github.com/appnexus/pyrobuf',
     author='AppNexus',
-    setup_requires=['jinja2', 'cython'],
-    install_requires=['jinja2', 'cython'],
+    setup_requires=['jinja2', 'cython >= 0.23'],
+    install_requires=['jinja2', 'cython >= 0.23'],
 )

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,9 @@ setup(
               'list_and_util': ListAndUtil},
     entry_points={
         'console_scripts': ['pyrobuf = pyrobuf.__main__:main'],
+        'distutils.setup_keywords': [
+                'pyrobuf_modules = pyrobuf.setuptools_ext:pyrobuf_modules',
+        ],
     },
     description='A Cython based protobuf compiler',
     long_description=open(os.path.join(HERE, 'README.md')).read(),

--- a/setup.py
+++ b/setup.py
@@ -104,4 +104,5 @@ setup(
     url='https://github.com/appnexus/pyrobuf',
     author='AppNexus',
     setup_requires=['jinja2', 'cython'],
+    install_requires=['jinja2', 'cython'],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ import distutils.log
 
 from setuptools import setup, find_packages, Command
 from setuptools.command.install import install as _install
-from jinja2 import Environment, PackageLoader
-from Cython.Build import cythonize
 
 
 VERSION = "0.5.5"
@@ -50,6 +48,7 @@ class install(_install):
         self.execute(_post_install, (self, ), msg="Running post install task")
 
 def _post_install(command):
+    from Cython.Build import cythonize
     command.announce('Building & installing pyrobuf_util and pyrobuf_list', level=distutils.log.INFO)
     setup(name="pyrobuf_list_and_util",
           version=VERSION,
@@ -58,6 +57,7 @@ def _post_install(command):
           script_args=['build', 'install'])
 
 def _pre_install(command):
+    from jinja2 import Environment, PackageLoader
     env = Environment(loader=PackageLoader('pyrobuf.protobuf', 'templates'))
 
     name_pyx = 'pyrobuf_list.pyx'
@@ -103,4 +103,5 @@ setup(
     long_description=open(os.path.join(HERE, 'README.md')).read(),
     url='https://github.com/appnexus/pyrobuf',
     author='AppNexus',
+    setup_requires=['jinja2', 'cython'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
-import os
-import sys
-import distutils.log
-
 from setuptools import setup, find_packages, Command
 from setuptools.command.install import install as _install
+
+import os
+import sys
 
 
 VERSION = "0.5.5"
@@ -25,6 +24,7 @@ class GenerateList(Command):
         assert os.getcwd() == self.cwd, 'Must be in package root: %s' % self.cwd
         self.execute(_pre_install, (self, ), msg="Running pre install task")
 
+
 class ListAndUtil(Command):
 
     description = "compile and install pyrobuf_list and pyrobuf_util (for development)"
@@ -40,33 +40,26 @@ class ListAndUtil(Command):
         assert os.getcwd() == self.cwd, 'Must be in package root: %s' % self.cwd
         self.execute(_post_install, (self, ), msg="Running post install task")
 
+
 class install(_install):
-
     def run(self):
-        self.execute(_pre_install, (self, ), msg="Running pre install task")
-        _install.run(self)
-        self.execute(_post_install, (self, ), msg="Running post install task")
+        # By now the setup_requires deps have been fetched.
+        self.distribution.ext_modules = self.pyrobufize_builtins()
+        super(_install, self).run()
 
-def _post_install(command):
-    from Cython.Build import cythonize
-    command.announce('Building & installing pyrobuf_util and pyrobuf_list', level=distutils.log.INFO)
-    setup(name="pyrobuf_list_and_util",
-          version=VERSION,
-          ext_modules=cythonize([os.path.join(HERE, 'pyrobuf', 'src', '*.pyx')],
-                                include_path=[os.path.join(HERE, 'pyrobuf', 'src')]),
-          script_args=['build', 'install'])
+    @staticmethod
+    def pyrobufize_builtins():
+        from jinja2 import Environment, PackageLoader
+        from Cython.Build import cythonize
+        env = Environment(loader=PackageLoader('pyrobuf.protobuf', 'templates'))
 
-def _pre_install(command):
-    from jinja2 import Environment, PackageLoader
-    env = Environment(loader=PackageLoader('pyrobuf.protobuf', 'templates'))
+        name_pyx = 'pyrobuf_list.pyx'
+        name_pxd = 'pyrobuf_list.pxd'
 
-    name_pyx = 'pyrobuf_list.pyx'
-    name_pxd = 'pyrobuf_list.pxd'
+        templ_pyx = env.get_template('pyrobuf_list_pyx.tmpl')
+        templ_pxd = env.get_template('pyrobuf_list_pxd.tmpl')
 
-    templ_pyx = env.get_template('pyrobuf_list_pyx.tmpl')
-    templ_pxd = env.get_template('pyrobuf_list_pxd.tmpl')
-
-    listdict = {
+        listdict = {
             'DoubleList':   'double',
             'FloatList':    'float',
             'IntList':      'int',
@@ -75,17 +68,18 @@ def _pre_install(command):
             'Int64List':    'int64_t',
             'Uint64List':   'uint64_t',
             'CharList':     'char'
-    }
+        }
 
-    path = os.path.join(HERE, 'pyrobuf', 'src', name_pyx)
-    command.announce('    Generating {0}'.format(path), level=distutils.log.INFO)
-    with open(path, 'w') as fp:
-        fp.write(templ_pyx.render({'def': listdict, 'version_major': sys.version_info.major}))
+        path = os.path.join(HERE, 'pyrobuf', 'src', name_pyx)
+        with open(path, 'w') as fp:
+            fp.write(templ_pyx.render({'def': listdict, 'version_major': sys.version_info.major}))
 
-    path = os.path.join(HERE, 'pyrobuf', 'src', name_pxd)
-    command.announce('    Generating {0}'.format(path), level=distutils.log.INFO)
-    with open(path, 'w') as fp:
-        fp.write(templ_pxd.render({'def': listdict, 'version_major': sys.version_info.major}))
+        path = os.path.join(HERE, 'pyrobuf', 'src', name_pxd)
+        with open(path, 'w') as fp:
+            fp.write(templ_pxd.render({'def': listdict, 'version_major': sys.version_info.major}))
+
+        return cythonize(['pyrobuf/src/*.pyx'],
+                         include_path=['pyrobuf/src'])
 
 
 setup(
@@ -97,7 +91,7 @@ setup(
               'generate_list': GenerateList,
               'list_and_util': ListAndUtil},
     entry_points={
-        'console_scripts': ['pyrobuf = pyrobuf.__main__:main']
+        'console_scripts': ['pyrobuf = pyrobuf.__main__:main'],
     },
     description='A Cython based protobuf compiler',
     long_description=open(os.path.join(HERE, 'README.md')).read(),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages, Command
+from setuptools import setup, find_packages
 from setuptools.command.install import install as _install
 
 import os
@@ -7,38 +7,6 @@ import sys
 
 VERSION = "0.5.5"
 HERE = os.path.dirname(os.path.abspath(__file__))
-
-
-class GenerateList(Command):
-
-    description = "generate pyrobuf_list pxd and pyd (for development)"
-    user_options = []
-
-    def initialize_options(self):
-        self.cwd = None
-
-    def finalize_options(self):
-        self.cwd = os.getcwd()
-
-    def run(self):
-        assert os.getcwd() == self.cwd, 'Must be in package root: %s' % self.cwd
-        self.execute(_pre_install, (self, ), msg="Running pre install task")
-
-
-class ListAndUtil(Command):
-
-    description = "compile and install pyrobuf_list and pyrobuf_util (for development)"
-    user_options = []
-
-    def initialize_options(self):
-        self.cwd = None
-
-    def finalize_options(self):
-        self.cwd = os.getcwd()
-
-    def run(self):
-        assert os.getcwd() == self.cwd, 'Must be in package root: %s' % self.cwd
-        self.execute(_post_install, (self, ), msg="Running post install task")
 
 
 class install(_install):
@@ -87,9 +55,7 @@ setup(
     version=VERSION,
     packages=find_packages(),
     include_package_data=True,
-    cmdclass={'install': install,
-              'generate_list': GenerateList,
-              'list_and_util': ListAndUtil},
+    cmdclass={'install': install},
     entry_points={
         'console_scripts': ['pyrobuf = pyrobuf.__main__:main'],
         'distutils.setup_keywords': [


### PR DESCRIPTION
This should make it easier to install Pyrobuf. Currently, `pip install pyrobuf` will fail without the jinja2 and cython packages, with this change it seems to be succeeding for me in a clean virtualenv.

Jinja2 and Cython will be fetched automatically by setuptools; there are still gotchas with this approach (setuptools will use easy_install, which uses a different config file than pip, so people with private repos will need to be aware) but I think it's the best that can be done for now.