### PR TITLE
Add extension modules for every setup.py command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.c
 *.pyc
 *.so
+*.pyd
 build/
 out/
 messages/*.proto

--- a/README.md
+++ b/README.md
@@ -35,18 +35,21 @@ You can help make it so!
 
 Fork and clone the repository, then run:
 
-    $ python setup.py build
+    $ python setup.py develop
 
-It will generate the platform specific pyrobuf_list them compile
+It will generate the platform specific pyrobuf_list then compile
 the pyrobuf_list and pyrobuf_util modules.
 
 You can then run the test suite (a work in progress) using py.test directly:
 
-    $ PYTHONPATH=build/lib.<platform>-<python version> py.test
+    $ PYTHONPATH=. py.test
 
 Or using the `test` command (which installs pytest if not already available):
 
     $ python setup.py test
+
+Re-running the `develop` or `test` commands will automatically re-build the
+pyrobuf_list and pyrobuf_util modules if necessary.
 
 The `clean` command does the house keeping for you:
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ You can help make it so!
 
 Fork and clone the repository, then run:
 
-    $ python setup.py generate_list list_and_util
+    $ python setup.py build
 
 It will generate the platform specific pyrobuf_list them compile and install
 the pyrobuf_list and pyrobuf_util modules.
 
 You can then run the test suite (a work in progress) using py.test:
 
-    $ PYTHONPATH=. py.test
+    $ PYTHONPATH=build/lib.<platform>-<python version> py.test
 
 `test_gen_message` will attempt to process all the proto files in
 `tests/proto`.
@@ -59,7 +59,6 @@ Improving testing is on the cards.
 
 You may very well be able to just use pyrobuf as is ... just pip it!
 
-**You need `jinja2` and `cython` installed prior to installing pyrobuf.**
 ```
 $ pip install pyrobuf
 ```
@@ -70,8 +69,7 @@ exception:
 
     $ python -c "import pyrobuf_list"
 
-If it does raise an exception (are you sure you had jinja2 and cython installed
-prior to trying `pip install pyrobuf`?), try:
+If it does raise an exception try:
 
 ```
 $ pip install pyrobuf -v -v -v --upgrade --force --no-cache

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Fork and clone the repository, then run:
 
     $ python setup.py build
 
-It will generate the platform specific pyrobuf_list them compile and install
+It will generate the platform specific pyrobuf_list them compile
 the pyrobuf_list and pyrobuf_util modules.
 
 You can then run the test suite (a work in progress) using py.test:

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,10 @@ class clean(_clean):
         self.__remove_file(os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PXD))
         self.__remove_file(os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PYX))
 
-        self.__remove_file(os.path.join(HERE, 'pyrobuf_list.so'))
-        self.__remove_file(os.path.join(HERE, 'pyrobuf_util.so'))
+        for suffix in (".so", ".pyd"):
+            self.__remove_file(os.path.join(HERE, 'pyrobuf_list' + suffix))
+            self.__remove_file(os.path.join(HERE, 'pyrobuf_util' + suffix))
+
 
 class test(_test):
 
@@ -67,6 +69,7 @@ class test(_test):
         import pytest
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
+
 
 class PyrobufDistribution(Distribution):
 

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,62 @@
-from setuptools import setup, find_packages, Command
-from setuptools.command.install import install as _install
+from distutils.command.clean import clean as _clean
+from distutils.dir_util import remove_tree
+from distutils import log
+
+from setuptools import setup, find_packages, Command, Distribution
 
 import os
+import os.path
 import sys
 
 
-VERSION = "0.5.6"
+VERSION = "0.5.7"
 HERE = os.path.dirname(os.path.abspath(__file__))
+PYROBUF_LIST_PXD = "pyrobuf_list.pxd"
+PYROBUF_LIST_PYX = "pyrobuf_list.pyx"
+
+
+class clean(_clean):
+    def __clean_tree(self, tree):
+        for dirpath, dirnames, filenames in os.walk(tree):
+            for dirname in dirnames:
+                if dirname in ('__pycache__', 'build'):
+                    remove_tree(os.path.join(dirpath, dirname), verbose=self.verbose, dry_run=self.dry_run)
+
+        for dirpath, dirnames, filenames in os.walk(tree):
+            for filename in filenames:
+                if any(filename.endswith(suffix) for suffix in (".so", ".pyd", ".dll", ".pyc")):
+                    self.__remove_file(os.path.join(dirpath, filename))
+                    continue
+                extension = os.path.splitext(filename)[1]
+                if extension in ['.c', '.h']:
+                    pyx_file = str.replace(filename, extension, '.pyx')
+                    if os.path.exists(os.path.join(dirpath, pyx_file)):
+                        self.__remove_file(os.path.join(dirpath, filename))
+
+    def __remove_file(self, full_path):
+        if os.path.exists(full_path):
+            if not self.dry_run:
+                os.unlink(full_path)
+            if self.verbose >= 1:
+                log.info("removing '%s'" % full_path)
+
+    def run(self):
+        _clean.run(self)
+
+        self.__clean_tree(os.path.join(HERE, 'pyrobuf'))
+        self.__clean_tree(os.path.join(HERE, 'tests'))
+
+        tests_out = os.path.join(HERE, 'tests', 'out')
+        if os.path.isdir(tests_out):
+            remove_tree(tests_out, verbose=self.verbose, dry_run=self.dry_run)
+
+        self.__remove_file(os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PXD))
+        self.__remove_file(os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PYX))
+
 
 class GenerateList(Command):
 
-    description = "generate pyrobuf_list pxd and pyd (for development)"
+    description = "generate pyrobuf_list pxd and pyx (for development)"
     user_options = []
 
     def initialize_options(self):
@@ -20,23 +66,22 @@ class GenerateList(Command):
         self.cwd = os.getcwd()
 
     def run(self):
-        assert os.getcwd() == self.cwd, 'Must be in package root: %s' % self.cwd
-        self.execute(install.pyrobufize_builtins, (), msg="Running pre install task")
+        # This command remains for backward compatibility
+        self.distribution.run_command('build')
 
-class install(_install):
-    def run(self):
+
+class PyrobufDistribution(Distribution):
+    def run_commands(self):
         # By now the setup_requires deps have been fetched.
-        self.distribution.ext_modules = self.pyrobufize_builtins()
-        _install.run(self)
+        if not self.ext_modules:
+            self.ext_modules = list()
+        self.ext_modules.extend(self.pyrobufize_builtins())
+        Distribution.run_commands(self)
 
-    @staticmethod
-    def pyrobufize_builtins():
+    def pyrobufize_builtins(self):
         from jinja2 import Environment, PackageLoader
         from Cython.Build import cythonize
         env = Environment(loader=PackageLoader('pyrobuf.protobuf', 'templates'))
-
-        name_pyx = 'pyrobuf_list.pyx'
-        name_pxd = 'pyrobuf_list.pxd'
 
         templ_pyx = env.get_template('pyrobuf_list_pyx.tmpl')
         templ_pxd = env.get_template('pyrobuf_list_pxd.tmpl')
@@ -52,24 +97,33 @@ class install(_install):
             'CharList':     'char'
         }
 
-        path = os.path.join(HERE, 'pyrobuf', 'src', name_pyx)
-        with open(path, 'w') as fp:
-            fp.write(templ_pyx.render({'def': listdict, 'version_major': sys.version_info.major}))
+        path = os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PYX)
+        if not os.path.exists(path) or os.path.getmtime(path) < os.path.getmtime(templ_pyx.filename):
+            if not self.dry_run:
+                with open(path, 'w') as fp:
+                    fp.write(templ_pyx.render({'def': listdict, 'version_major': sys.version_info.major}))
+            if self.verbose >= 1:
+                log.info("rendering '%s' from '%s'" % (PYROBUF_LIST_PYX, templ_pyx.filename))
 
-        path = os.path.join(HERE, 'pyrobuf', 'src', name_pxd)
-        with open(path, 'w') as fp:
-            fp.write(templ_pxd.render({'def': listdict, 'version_major': sys.version_info.major}))
+        path = os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PXD)
+        if not os.path.exists(path) or os.path.getmtime(path) < os.path.getmtime(templ_pxd.filename):
+            if not self.dry_run:
+                with open(path, 'w') as fp:
+                    fp.write(templ_pxd.render({'def': listdict, 'version_major': sys.version_info.major}))
+            if self.verbose >= 1:
+                log.info("rendering '%s' from '%s'" % (PYROBUF_LIST_PXD, templ_pxd.filename))
 
         return cythonize(['pyrobuf/src/*.pyx'],
                          include_path=['pyrobuf/src'])
 
 
 setup(
+    distclass=PyrobufDistribution,
     name="pyrobuf",
     version=VERSION,
     packages=find_packages(),
     include_package_data=True,
-    cmdclass={'install': install, 'generate_list': GenerateList},
+    cmdclass={'clean': clean, 'generate_list': GenerateList},
     entry_points={
         'console_scripts': ['pyrobuf = pyrobuf.__main__:main'],
         'distutils.setup_keywords': [
@@ -82,4 +136,5 @@ setup(
     author='AppNexus',
     setup_requires=['jinja2', 'cython >= 0.23'],
     install_requires=['jinja2', 'cython >= 0.23'],
+    zip_safe=False,
 )

--- a/tests/create_message.py
+++ b/tests/create_message.py
@@ -1,17 +1,25 @@
 import os
 import sys
 
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
-LIB = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                           if name.startswith('lib')].pop())
-
-sys.path.insert(0, LIB)
+import pytest
 
 import messages.test_message_pb2 as google_test
 
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, 'build')
+
+
+@pytest.fixture(scope='module')
+def lib():
+    lib_path = os.path.join(BUILD, [name for name in os.listdir(BUILD)
+                                    if name.startswith('lib')].pop())
+    if lib not in sys.path:
+        sys.path.insert(0, lib)
+    return lib_path
+
+
 def create_an_test():
-    print LIB
+    # print LIB
     import test_message_proto as an_test
     test = an_test.Test()
     test.timestamp = 539395200

--- a/tests/test_issue_11.py
+++ b/tests/test_issue_11.py
@@ -1,21 +1,29 @@
 import os
 import sys
 
+import pytest
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 BUILD = os.path.join(HERE, 'build')
-LIB = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                           if name.startswith('lib')].pop())
-
-sys.path.insert(0, LIB)
 
 
-def test_before_overflow():
+@pytest.fixture(scope='module')
+def lib():
+    lib_path = os.path.join(BUILD, [name for name in os.listdir(BUILD)
+                                    if name.startswith('lib')].pop())
+    if lib not in sys.path:
+        sys.path.insert(0, lib)
+    return lib_path
+
+
+def test_before_overflow(lib):
     from issue_11_proto import A
     a = A()
     a.a0 = 0x7FFFFFFF
     assert A.FromString(a.SerializeToString()).a0 == 2147483647
 
-def test_after_overflow():
+
+def test_after_overflow(lib):
     from issue_11_proto import A
     a = A()
     a.a0 = 0x80000000

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,7 +1,11 @@
 import unittest
 
+import pytest
+
 from create_message import *
 
+
+@pytest.mark.usefixtures('lib')
 class MessageTest(unittest.TestCase):
 
     def test_ser_deser(self):


### PR DESCRIPTION
Currently the pyrobuf setup.py script will add the `pyrobuf_list` and `pyrobuf_util` extension modules to the distribution configuration only when the setup.py `install` command is executed. This PR enhances the setup script to add the extension modules for every setup.py command. This means, for example, that one can use the command:

```
python setup.py build
```

to build (or rebuild) pyrobuf, or the command:

```
python setup.py develop
```

to install pyrobuf in editable mode.

Furthermore, this PR enhances the setup.py `clean` command to remove temporary artifacts created by the pyrobuf build process and ensures that setup.py honours the 'dry_run' and 'verbose' command line arguments.

Finally, this PR uses pytest fixtures to add the test build directory to the system path when running tests in the `test_issue_11` and `test_message` modules, so that these tests work correctly even if the build directory does not exist when the `py.test` command is first executed.