### PR TITLE
Fixes for python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ dist/
 *.egg-info
 pyrobuf/src/pyrobuf_list.*
 .cache/
+.eggs/
+tests/out/
+tests/build/
+/.tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include README.md
 include pyrobuf/protobuf/templates/*.tmpl
 include pyrobuf/src/ansidecl.h
 include pyrobuf/src/strndup.c
-include pyrobuf/src/*.pxd
-include pyrobuf/src/*.pyx
+include pyrobuf/src/pyrobuf_util.pxd
+include pyrobuf/src/pyrobuf_util.pyx

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -46,7 +46,7 @@ cdef class {{ name }}:
     cpdef void MergeFrom(self, {{ name }} other_msg)
     cpdef int MergeFromString(self, data, size=*) except -1
     cpdef int ParseFromString(self, data, size=*, bint reset=*) except -1
-    cpdef bytearray SerializePartialToString(self)
+    cpdef str SerializePartialToString(self)
 
     cdef int _protobuf_deserialize(self, const unsigned char *memory, int size)
 

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -158,9 +158,14 @@ cdef class {{ name }}:
                 {% endfor %}
                 else:
                     raise Exception("not a valid value for enum {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }}")
-            {%- elif field.type in ('string', 'bytes') %}
+            {%- elif field.type in ('string', 'bytes') and version_major == 2 %}
                 if type(val) is unicode:
                     self._{{ field.name }}.append(str(val))
+                else:
+                    self._{{ field.name }}.append(val)
+            {%- elif field.type in ('string', 'bytes') and version_major != 2 %}
+                if isinstance(val, bytes):
+                    self._{{ field.name }}.append(str(val, encoding='iso-8859-1'))
                 else:
                     self._{{ field.name }}.append(val)
             {%- else %}
@@ -178,9 +183,14 @@ cdef class {{ name }}:
                 {% endfor %}
             else:
                 raise Exception("not a valid value for enum {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }}")
-            {%- elif field.type in ('string', 'bytes') %}
+            {%- elif field.type in ('string', 'bytes') and version_major == 2 %}
             if type(value) is unicode:
                 self._{{ field.name }} = str(value)
+            else:
+                self._{{ field.name }} = value
+            {%- elif field.type in ('string', 'bytes') and version_major != 2 %}
+            if isinstance(value, bytes):
+                self._{{ field.name }} = str(value, encoding='iso-8859-1')
             else:
                 self._{{ field.name }} = value
             {%- else %}
@@ -260,7 +270,11 @@ cdef class {{ name }}:
                 current_offset += {{ field.name }}_elt._protobuf_deserialize(memory+current_offset, field_size)
                 {%- elif field.type in ('string', 'bytes') %}
                 field_size = get_varint64(memory, &current_offset)
+                    {%- if version_major == 2 %}
                 {{ field.name }}_elt = str(memory[current_offset:current_offset + field_size])
+                    {%- else %}
+                {{ field.name }}_elt = str(memory[current_offset:current_offset + field_size], encoding='iso-8859-1')
+                    {%- endif %}
                 current_offset += field_size
                 {%- elif field.fixed_width == true %}
                 {{ field.name }}_elt = (<{{ field.c_type }} *>&memory[current_offset])[0]
@@ -281,7 +295,11 @@ cdef class {{ name }}:
 
         {%- elif field.type in ('string', 'bytes') %}
                 field_size = get_varint64(memory, &current_offset)
+            {%- if version_major == 2 %}
                 self._{{ field.name }} = str(memory[current_offset:current_offset + field_size])
+            {%- else %}
+                self._{{ field.name }} = str(memory[current_offset:current_offset + field_size], encoding='iso-8859-1')
+            {%- endif %}
                 current_offset += field_size
 
         {%- elif field.type == 'enum' %}
@@ -483,6 +501,11 @@ cdef class {{ name }}:
         cdef int buf
         cdef bint already_present_in_parent = self._is_present_in_parent
 
+        {%- if version_major != 2 %}
+        if isinstance(data, str):
+            data = data.encode('iso-8859-1')
+        {%- endif %}
+
         if size is None:
             size = len(data)
 
@@ -510,6 +533,11 @@ cdef class {{ name }}:
         """
         cdef int buf
         cdef bint already_present_in_parent = self._is_present_in_parent
+
+        {%- if version_major != 2 %}
+        if isinstance(data, str):
+            data = data.encode('iso-8859-1')
+        {%- endif %}
 
         if size is None:
             size = len(data)
@@ -549,8 +577,10 @@ cdef class {{ name }}:
             {%- if field.type == 'message' %}
         cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} {{ field.name }}_elt
         cdef bytearray {{ field.name }}_elt_buf
-            {%- elif field.type in ('string', 'bytes') %}
+            {%- elif field.type in ('string', 'bytes') and version_major == 2 %}
         cdef str {{ field.name }}_elt
+            {%- elif field.type in ('string', 'bytes') and version_major != 2 %}
+        cdef bytes {{ field.name }}_elt
             {%- elif field.type == 'enum' %}
         cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }} {{ field.name }}_elt
             {%- else %}
@@ -567,6 +597,9 @@ cdef class {{ name }}:
         cdef bytearray {{ field.name }}_buf
         if self._{{ field.name }}._is_present_in_parent:
 
+        {%- elif field.type in ('string', 'bytes') and version_major != 2 %}
+        cdef bytes {{ field.name }}_bytes
+        if self._{{ field.name }}_isSet:
         {#- !messages and !repeated fields can all have default values #}
         {%- else %}
         if self._{{ field.name }}_isSet:
@@ -607,7 +640,11 @@ cdef class {{ name }}:
             for i in range(length):
                 set_varint64(key, buf)
                 {%- if field.type in ('string', 'bytes') %}
+                    {%- if version_major == 2 %}
                 {{ field.name }}_elt = <str>self._{{ field.name }}[i]
+                    {%- else %}
+                {{ field.name }}_elt = self._{{ field.name }}[i].encode('iso-8859-1')
+                    {%- endif %}
                 set_varint64(len({{ field.name }}_elt), buf)
                 buf += {{ field.name }}_elt
                 {%- elif field.type == 'message' %}
@@ -632,10 +669,16 @@ cdef class {{ name }}:
             set_varint64(len({{ field.name }}_buf), buf)
             buf += {{ field.name }}_buf
 
-        {%- elif field.type in ('string', 'bytes') %}
+        {%- elif field.type in ('string', 'bytes') and version_major == 2 %}
             set_varint64(key, buf)
             set_varint64(len(self._{{ field.name }}), buf)
             buf += self._{{ field.name }}
+
+        {%- elif field.type in ('string', 'bytes') and version_major != 2 %}
+            set_varint64(key, buf)
+            {{ field.name }}_bytes = self._{{ field.name }}.encode('iso-8859-1')
+            set_varint64(len({{ field.name }}_bytes), buf)
+            buf += {{ field.name }}_bytes
 
         {%- elif field.fixed_width == true %}
             set_varint64(key, buf)
@@ -690,7 +733,11 @@ cdef class {{ name }}:
 
         cdef bytearray buf = bytearray()
         self._protobuf_serialize(buf)
-        return buf
+    {%- if version_major == 2 %}
+        return str(buf)
+    {%- else %}
+        return str(buf, encoding='iso-8859-1')
+    {%- endif %}
 
     cpdef bytearray SerializePartialToString(self):
         """
@@ -701,7 +748,11 @@ cdef class {{ name }}:
         """
         cdef bytearray buf = bytearray()
         self._protobuf_serialize(buf)
-        return buf
+    {%- if version_major == 2 %}
+        return str(buf)
+    {%- else %}
+        return str(buf, encoding='iso-8859-1')
+    {%- endif %}
 
     def SetInParent(self):
         """

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -698,10 +698,10 @@ cdef class {{ name }}:
 
     def SerializeToString(self):
         """
-        Serialize the message class into a bytearray of protobuf encoded binary data.
+        Serialize the message class into a string of protobuf encoded binary data.
 
         Returns:
-            bytearray: a bytearray of binary data
+            str: a string of binary data
         """
     {%- if message.fields|selectattr('type', 'equalto', 'message')|selectattr('modifier', 'equalto', 'repeated')|first is defined %}
         cdef int i
@@ -739,12 +739,12 @@ cdef class {{ name }}:
         return str(buf, encoding='iso-8859-1')
     {%- endif %}
 
-    cpdef bytearray SerializePartialToString(self):
+    cpdef str SerializePartialToString(self):
         """
-        Serialize the message class into a bytearray of protobuf encoded binary data.
+        Serialize the message class into a string of protobuf encoded binary data.
 
         Returns:
-            bytearray: a bytearray of binary data
+            str: a bytearray of binary data
         """
         cdef bytearray buf = bytearray()
         self._protobuf_serialize(buf)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = .cache .eggs .git .tox build tests/messages

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.command.clean import clean as _clean
 from distutils.dir_util import remove_tree
 from distutils import log
 
-from setuptools import setup, find_packages, Command, Distribution
+from setuptools import setup, find_packages, Distribution
 from setuptools.command.test import test as _test
 
 import os
@@ -10,7 +10,7 @@ import os.path
 import sys
 
 
-VERSION = "0.5.7"
+VERSION = "0.5.8"
 HERE = os.path.dirname(os.path.abspath(__file__))
 PYROBUF_LIST_PXD = "pyrobuf_list.pxd"
 PYROBUF_LIST_PYX = "pyrobuf_list.pyx"
@@ -54,9 +54,11 @@ class clean(_clean):
         self.__remove_file(os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PXD))
         self.__remove_file(os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PYX))
 
-        for suffix in (".so", ".pyd"):
-            self.__remove_file(os.path.join(HERE, 'pyrobuf_list' + suffix))
-            self.__remove_file(os.path.join(HERE, 'pyrobuf_util' + suffix))
+        for filename in os.listdir(HERE):
+            for prefix in ("pyrobuf_list", "pyrobuf_util"):
+                for suffix in (".so", ".pyd"):
+                    if filename.startswith(prefix) and filename.endswith(suffix):
+                        self.__remove_file(os.path.join(HERE, filename))
 
 
 class test(_test):
@@ -99,21 +101,21 @@ class PyrobufDistribution(Distribution):
             'CharList':     'char'
         }
 
+        # Even if PYROBUF_LIST_PYX and PYROBUF_LIST_PXD already exist they should be re-built because
+        # we don't know whether they were built using *this* version of Python.
         path = os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PYX)
-        if not os.path.exists(path) or os.path.getmtime(path) < os.path.getmtime(templ_pyx.filename):
-            if not self.dry_run:
-                with open(path, 'w') as fp:
-                    fp.write(templ_pyx.render({'def': listdict, 'version_major': sys.version_info.major}))
-            if self.verbose >= 1:
-                log.info("rendering '%s' from '%s'" % (PYROBUF_LIST_PYX, templ_pyx.filename))
+        if not self.dry_run:
+            with open(path, 'w') as fp:
+                fp.write(templ_pyx.render({'def': listdict, 'version_major': sys.version_info.major}))
+        if self.verbose >= 1:
+            log.info("rendering '%s' from '%s'" % (PYROBUF_LIST_PYX, templ_pyx.filename))
 
         path = os.path.join(HERE, 'pyrobuf', 'src', PYROBUF_LIST_PXD)
-        if not os.path.exists(path) or os.path.getmtime(path) < os.path.getmtime(templ_pxd.filename):
-            if not self.dry_run:
-                with open(path, 'w') as fp:
-                    fp.write(templ_pxd.render({'def': listdict, 'version_major': sys.version_info.major}))
-            if self.verbose >= 1:
-                log.info("rendering '%s' from '%s'" % (PYROBUF_LIST_PXD, templ_pxd.filename))
+        if not self.dry_run:
+            with open(path, 'w') as fp:
+                fp.write(templ_pxd.render({'def': listdict, 'version_major': sys.version_info.major}))
+        if self.verbose >= 1:
+            log.info("rendering '%s' from '%s'" % (PYROBUF_LIST_PXD, templ_pxd.filename))
 
         return cythonize(['pyrobuf/src/*.pyx'],
                          include_path=['pyrobuf/src'])
@@ -136,7 +138,7 @@ setup(
     long_description=open(os.path.join(HERE, 'README.md')).read(),
     url='https://github.com/appnexus/pyrobuf',
     author='AppNexus',
-    tests_require=['pytest', 'protobuf >= 2.6.0, <3'],
+    tests_require=['pytest'] + (['protobuf >= 2.6.0, <3'] if sys.version_info.major == 2 else []),
     setup_requires=['jinja2', 'cython >= 0.23'],
     install_requires=['jinja2', 'cython >= 0.23'],
     zip_safe=False,

--- a/tests/create_message.py
+++ b/tests/create_message.py
@@ -1,21 +1,8 @@
-import os
 import sys
 
-import pytest
 
-import messages.test_message_pb2 as google_test
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
-
-
-@pytest.fixture(scope='module')
-def lib():
-    lib_path = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                    if name.startswith('lib')].pop())
-    if lib not in sys.path:
-        sys.path.insert(0, lib)
-    return lib_path
+if sys.version_info.major == 2:
+    import messages.test_message_pb2 as google_test
 
 
 def create_an_test():
@@ -67,53 +54,55 @@ def create_an_test():
 
     return test
 
-def create_google_test():
-    test = google_test.Test()
-    test.timestamp = 539395200
-    test.field = 10689
-    test.string_field = "go goats!"
 
-    for i in range(5):
-        test.list_fieldx.append(i * 100)
+if sys.version_info.major == 2:
+    def create_google_test():
+        test = google_test.Test()
+        test.timestamp = 539395200
+        test.field = 10689
+        test.string_field = "go goats!"
 
-    test.substruct.field1 = 12345
-    test.substruct.field2 = "hello"
-    test.substruct.field3.field1 = 1419.67
-    test.substruct.field3.ss2_field2 = "goodbye"
-    test.substruct.list.append(354.94)
+        for i in range(5):
+            test.list_fieldx.append(i * 100)
 
-    obj = test.substruct.list_object.add()
-    obj.field1 = 3.14159
-    obj.ss2_field2 = "pi"
+        test.substruct.field1 = 12345
+        test.substruct.field2 = "hello"
+        test.substruct.field3.field1 = 1419.67
+        test.substruct.field3.ss2_field2 = "goodbye"
+        test.substruct.list.append(354.94)
 
-    test.substruct.list_string.append("something")
+        obj = test.substruct.list_object.add()
+        obj.field1 = 3.14159
+        obj.ss2_field2 = "pi"
 
-    test.test_ref.timestamp = 539395200
-    test.test_ref.field1 = 1111
-    test.test_ref.field2 = 1.2345
-    test.test_ref.field3 = "foo"
+        test.substruct.list_string.append("something")
 
-    obj = test.list_ref.add()
-    obj.timestamp = 539395200
-    obj.field1 = 1111
-    obj.field2 = 1.2345
-    obj.field3 = "foo"
+        test.test_ref.timestamp = 539395200
+        test.test_ref.field1 = 1111
+        test.test_ref.field2 = 1.2345
+        test.test_ref.field3 = "foo"
 
-    test.another_substruct.string_field = "what's up?"
-    test.another_substruct.fixed_string_field = "nothing much"
-    test.another_substruct.int_field = 24
-    test.another_substruct.another_int_field = 87
+        obj = test.list_ref.add()
+        obj.timestamp = 539395200
+        obj.field1 = 1111
+        obj.field2 = 1.2345
+        obj.field3 = "foo"
 
-    test.another_substruct.substruct_ref.timestamp = 539395200
-    test.another_substruct.substruct_ref.field1 = 1111
-    test.another_substruct.substruct_ref.field2 = 1.2345
-    test.another_substruct.substruct_ref.field3 = "foo"
+        test.another_substruct.string_field = "what's up?"
+        test.another_substruct.fixed_string_field = "nothing much"
+        test.another_substruct.int_field = 24
+        test.another_substruct.another_int_field = 87
 
-    test.req_field = -80914
-    test.negative_32 = -1
+        test.another_substruct.substruct_ref.timestamp = 539395200
+        test.another_substruct.substruct_ref.field1 = 1111
+        test.another_substruct.substruct_ref.field2 = 1.2345
+        test.another_substruct.substruct_ref.field3 = "foo"
 
-    return test
+        test.req_field = -80914
+        test.negative_32 = -1
 
-def create_buffer():
-    test = create_google_test()
-    return test.SerializeToString()
+        return test
+
+    def create_buffer():
+        test = create_google_test()
+        return test.SerializeToString()

--- a/tests/performances.py
+++ b/tests/performances.py
@@ -1,9 +1,20 @@
+import os
+import sys
 import time
+
+from create_message import *
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, 'build')
+lib_path = os.path.join(BUILD, [name for name in os.listdir(BUILD)
+                                if name.startswith('lib')].pop())
+if lib_path not in sys.path:
+    sys.path.insert(0, lib_path)
 
 import messages.test_message_pb2 as google_test
 import test_message_proto as an_test
 
-from create_message import *
 
 def main():
     t1 = create_google_test()

--- a/tests/proto_lib_fixture.py
+++ b/tests/proto_lib_fixture.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest
+
+from distutils.util import get_platform
+
+
+@pytest.fixture(scope='session')
+def proto_lib():
+    here = os.path.dirname(os.path.abspath(__file__))
+    build = os.path.join(here, 'build')
+    lib_path = os.path.join(build, "lib.{0}-{1}".format(get_platform(), sys.version[0:3]))
+
+    if lib_path not in sys.path:
+        sys.path.insert(0, lib_path)
+
+    return lib_path

--- a/tests/test_deprecated_field.py
+++ b/tests/test_deprecated_field.py
@@ -1,28 +1,14 @@
-import os
-import sys
 import unittest
 import warnings
 
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
-TestDeprecatedField = None
-
-
+@pytest.mark.usefixtures('proto_lib')
 class DecimalDefaultsTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
-        global TestDeprecatedField
-        from test_deprecated_field_proto import TestDeprecatedField
-
     def setUp(self):
+        from test_deprecated_field_proto import TestDeprecatedField
         warnings.filterwarnings("error")
         self.message = TestDeprecatedField()
 

--- a/tests/test_has_field.py
+++ b/tests/test_has_field.py
@@ -1,10 +1,7 @@
-import os
-import sys
 import unittest
 
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 Test = None
@@ -13,15 +10,10 @@ TestSs1 = None
 TestSs1Thing = None
 
 
+@pytest.mark.usefixtures('proto_lib')
 class HasFieldTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
         global Test, TestRef, TestSs1, TestSs1Thing
         from test_message_proto import Test, TestSs1, TestSs1Thing
         from test_ref_message_proto import TestRef

--- a/tests/test_imported_enums.py
+++ b/tests/test_imported_enums.py
@@ -1,9 +1,7 @@
-import os
-import sys
 import unittest
 
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 # These can't be imported until the test_imported_enums_proto module has been built.
@@ -13,17 +11,11 @@ ExposesInternalEnumConstantsMessage = None
 UsesImportedEnumsMessage = None
 
 
+@pytest.mark.usefixtures('proto_lib')
 class ImportedEnumsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
-        # At this point the test_imported_enums_proto will have been built and can be imported
-        global CLOSE, MSG_ONE, UsesImportedEnumsMessage, ExposesInternalEnumConstantsMessage
-
+        global CLOSE, MSG_ONE, ExposesInternalEnumConstantsMessage, UsesImportedEnumsMessage
         from test_multi_messages_toplevel_enums_proto import MSG_ONE, CLOSE
         from test_imported_enums_proto import UsesImportedEnumsMessage, ExposesInternalEnumConstantsMessage
 

--- a/tests/test_is_initialized.py
+++ b/tests/test_is_initialized.py
@@ -1,10 +1,7 @@
-import os
-import sys
 import unittest
 
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 TestIsInitialized = None
@@ -12,15 +9,10 @@ SubMessage = None
 TestWithRequiredSubMessage = None
 
 
+@pytest.mark.usefixtures('proto_lib')
 class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
         global TestIsInitialized, SubMessage, TestWithRequiredSubMessage
         from test_is_initialized_proto import TestIsInitialized, SubMessage, TestWithRequiredSubMessage
 

--- a/tests/test_issue_11.py
+++ b/tests/test_issue_11.py
@@ -1,29 +1,15 @@
-import os
-import sys
-
 import pytest
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+from proto_lib_fixture import proto_lib
 
 
-@pytest.fixture(scope='module')
-def lib():
-    lib_path = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                    if name.startswith('lib')].pop())
-    if lib not in sys.path:
-        sys.path.insert(0, lib)
-    return lib_path
-
-
-def test_before_overflow(lib):
+def test_before_overflow(proto_lib):
     from issue_11_proto import A
     a = A()
     a.a0 = 0x7FFFFFFF
     assert A.FromString(a.SerializeToString()).a0 == 2147483647
 
 
-def test_after_overflow(lib):
+def test_after_overflow(proto_lib):
     from issue_11_proto import A
     a = A()
     a.a0 = 0x80000000

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -74,7 +74,7 @@ class DoubleListTest(unittest.TestCase):
             x.append(i)
 
         x.remove(3)
-        self.assertEquals(x[3], 4)
+        self.assertEqual(x[3], 4)
 
         with self.assertRaises(ValueError):
             x.remove(7)

--- a/tests/test_merge_from.py
+++ b/tests/test_merge_from.py
@@ -1,12 +1,7 @@
-import os
-import sys
 import unittest
 
-import messages.test_message_pb2 as google_test
-
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 Test = None
@@ -14,15 +9,10 @@ TestSs1 = None
 TestSs3 = None
 
 
+@pytest.mark.usefixtures('proto_lib')
 class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
         global Test, TestSs1, TestSs3
         from test_message_proto import Test, TestSs1, TestSs3
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,24 +1,37 @@
+import sys
 import unittest
 
 import pytest
+from proto_lib_fixture import proto_lib
 
 from create_message import *
 
 
-@pytest.mark.usefixtures('lib')
+GOOGLE_SERIALIZED_MESSAGE = '\x08\x80\x89\x9a\x81\x02\x10\xc1S\x1a\tgo goats! \x00 d \xc8\x01 \xac\x02 \x90\x03*A\x08\xb9`\x12\x05hello\x1a\x12\tH\xe1z\x14\xae.\x96@\x12\x07goodbye!\xd7\xa3p=\n/v@*\r\tn\x86\x1b\xf0\xf9!\t@\x12\x02pi2\tsomething2\x17\x08\x80\x89\x9a\x81\x02\x10\xd7\x08\x19\x8d\x97n\x12\x83\xc0\xf3?"\x03fooB\x17\x08\x80\x89\x9a\x81\x02\x10\xd7\x08\x19\x8d\x97n\x12\x83\xc0\xf3?"\x03fooJ7\n\nwhat\'s up?\x12\x0cnothing much\x18\x18 W*\x17\x08\x80\x89\x9a\x81\x02\x10\xd7\x08\x19\x8d\x97n\x12\x83\xc0\xf3?"\x03fooP\xee\x87\xfb\xff\xff\xff\xff\xff\xff\x01X\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01'
+
+
+@pytest.mark.usefixtures('proto_lib')
 class MessageTest(unittest.TestCase):
 
     def test_ser_deser(self):
-        t1 = create_google_test()
+        if sys.version_info.major == 2:
+            t1 = create_google_test()
+            buf1 = t1.SerializeToString()
+        else:
+            buf1 = GOOGLE_SERIALIZED_MESSAGE
+
         t2 = create_an_test()
-        buf1 = t1.SerializeToString()
         buf2 = t2.SerializeToString()
 
         self.assertEqual(buf1, str(buf2))
 
-        t1.ParseFromString(buf1)
+        if sys.version_info.major == 2:
+            t1.ParseFromString(buf1)
+            buf1 = t1.SerializeToString()
+        else:
+            buf1 = GOOGLE_SERIALIZED_MESSAGE
+
         t2.ParseFromString(buf1)
-        buf1 = t1.SerializeToString()
         buf2 = t2.SerializeToString()
 
         self.assertEqual(buf1, str(buf2))
@@ -32,10 +45,10 @@ class MessageTest(unittest.TestCase):
 
     def test_dict(self):
         test = create_an_test()
-        json = test.SerializeToDict()
+        the_dict = test.SerializeToDict()
 
-        test.ParseFromDict(json)
-        self.assertEqual(json, test.SerializeToDict())
+        test.ParseFromDict(the_dict)
+        self.assertEqual(the_dict, test.SerializeToDict())
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_message_decimal_defaults.py
+++ b/tests/test_message_decimal_defaults.py
@@ -1,24 +1,16 @@
-import os
-import sys
 import unittest
 
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 TestDecimalDefaultsMessage = None
 
 
+@pytest.mark.usefixtures('proto_lib')
 class DecimalDefaultsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
         global TestDecimalDefaultsMessage
         from test_decimal_defaults_proto import TestDecimalDefaultsMessage
 

--- a/tests/test_message_field_types.py
+++ b/tests/test_message_field_types.py
@@ -1,24 +1,16 @@
-import os
-import sys
 import unittest
 
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 TestFieldTypes = None
 
 
-class MergeFromTest(unittest.TestCase):
+@pytest.mark.usefixtures('proto_lib')
+class MessageFieldTypesTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
         global TestFieldTypes
         from test_message_field_types_proto import TestFieldTypes
 

--- a/tests/test_message_init_kwargs.py
+++ b/tests/test_message_init_kwargs.py
@@ -1,10 +1,7 @@
-import os
-import sys
 import unittest
 
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 Test = None
@@ -12,15 +9,10 @@ TestSs1 = None
 TestSs3 = None
 
 
+@pytest.mark.usefixtures('proto_lib')
 class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
         global Test, TestSs1, TestSs3
         from test_message_proto import Test, TestSs1, TestSs3
 

--- a/tests/test_message_with_no_fields.py
+++ b/tests/test_message_with_no_fields.py
@@ -1,24 +1,16 @@
-import os
-import sys
 import unittest
 
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 EmptyMessageWithNoFields = None
 
 
+@pytest.mark.usefixtures('proto_lib')
 class EmptyMessageTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
         global EmptyMessageWithNoFields
         from test_empty_message_proto import EmptyMessageWithNoFields
 

--- a/tests/test_missing_lbraces.py
+++ b/tests/test_missing_lbraces.py
@@ -16,7 +16,7 @@ class TestMissingLBraces(unittest.TestCase):
 
         try:
             parser.parse(s)
-        except Exception, e:
+        except Exception as e:
             self.assertEqual("missing opening paren at pos 22: 'NO = 0;   '", str(e))
 
     def test_message_with_missing_lbrace_raises_exception(self):
@@ -31,5 +31,5 @@ class TestMissingLBraces(unittest.TestCase):
 
         try:
             parser.parse(s)
-        except Exception, e:
+        except Exception as e:
             self.assertEqual("missing opening paren at pos 25: 'required i'", str(e))

--- a/tests/test_string_defaults.py
+++ b/tests/test_string_defaults.py
@@ -1,24 +1,16 @@
-import os
-import sys
 import unittest
 
-
-HERE = os.path.dirname(os.path.abspath(__file__))
-BUILD = os.path.join(HERE, 'build')
+import pytest
+from proto_lib_fixture import proto_lib
 
 
 TestStringDefaultsMessage = None
 
 
+@pytest.mark.usefixtures('proto_lib')
 class StringDefaultsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        lib = os.path.join(BUILD, [name for name in os.listdir(BUILD)
-                                   if name.startswith('lib')].pop())
-
-        if lib not in sys.path:
-            sys.path.insert(0, lib)
-
         global TestStringDefaultsMessage
         from test_string_defaults_proto import TestStringDefaultsMessage
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py35
+
+[testenv]
+commands = {envpython} setup.py test
+deps =


### PR DESCRIPTION
This PR should address the issues raised in ticket #28. Pyrobuf now compiles and passes all current tests on both Python 2.7 and Python 3.5. I've added a tox.ini file so that [tox](https://testrun.org/tox/latest/) can be used to automatically test Pyrobuf on both versions.

One change worth noting is that `SerializeToString` and `SerialiazePartialToString` now return a string rather than a bytearray.