### PR TITLE
Signed varint problem with zigzag encoding

### DIFF
--- a/pyrobuf/src/pyrobuf_util.pyx
+++ b/pyrobuf/src/pyrobuf_util.pyx
@@ -86,37 +86,45 @@ def get_varint(data, offset=0):
     return get_varint64(data, &_offset)
 
 
-cdef int32_t get_signed_varint32(const unsigned char *memory, int *offset):
+cdef int32_t get_signed_varint32(const unsigned char *varint, int *offset):
     """
     Deserialize a signed protobuf varint starting from give offset in memory;
     update offset based on number of bytes consumed.
     """
-    cdef int32_t varint = 0
-    cdef int idx = 0
-    while memory[offset[0] + idx] >> 7:
-        varint += ((memory[offset[0] + idx] ^ 0x80) << (7 * idx))
-        idx += 1
+    cdef uint32_t value = 0
+    cdef int32_t base = 1
+    cdef int index = 0
+    cdef int val_byte
 
-    varint += (memory[offset[0] + idx] << (7 * idx))
-    offset[0] += (idx + 1)
-    return (varint >> 1) ^ (varint << 31)
+    while True:
+        val_byte = varint[offset[0] + index]
+        value += (val_byte & 0x7F) * base
+        if (val_byte & 0x80):
+            base *= 128
+            index += 1
+        else:
+            offset[0] += (index + 1)
+            return <int32_t>((value >> 1) ^ (-(value & 1))) # zigzag decoding
 
-
-cdef int64_t get_signed_varint64(const unsigned char *memory, int *offset):
+cdef int64_t get_signed_varint64(const unsigned char *varint, int *offset):
     """
     Deserialize a signed protobuf varint starting from give offset in memory;
     update offset based on number of bytes consumed.
     """
-    cdef int64_t varint = 0
-    cdef int idx = 0
-    while memory[offset[0] + idx] >> 7:
-        varint += ((memory[offset[0] + idx] ^ 0x80) << (7 * idx))
-        idx += 1
+    cdef uint64_t value = 0
+    cdef int64_t base = 1
+    cdef int index = 0
+    cdef int val_byte
 
-    varint += (memory[offset[0] + idx] << (7 * idx))
-    offset[0] += (idx + 1)
-    return (varint >> 1) ^ (varint << 63)
-
+    while True:
+        val_byte = varint[offset[0] + index]
+        value += (val_byte & 0x7F) * base
+        if (val_byte & 0x80):
+            base *= 128
+            index += 1
+        else:
+            offset[0] += (index + 1)
+            return <int64_t>((value >> 1) ^ (-(value & 1))) # zigzag decoding
 
 def get_signed_varint(data, offset=0):
     cdef int _offset = offset

--- a/pyrobuf/src/pyrobuf_util.pyx
+++ b/pyrobuf/src/pyrobuf_util.pyx
@@ -174,14 +174,19 @@ cdef int set_signed_varint32(int32_t varint, bytearray buf):
     Serialize an integer into a signed protobuf varint; return the number of
     bytes serialized.
     """
-    varint = (varint << 1) ^ (varint >> 31)
+    cdef uint32_t enc
     cdef int idx = 1
-    while varint >> 7:
-        buf.append(<unsigned char>(varint | 0x80))
-        varint >>= 7
+
+    enc = (varint << 1) ^ (varint >> 31) # zigzag encoding
+    bits = enc & 0x7f
+    enc >>= 7
+    while enc:
+        buf.append(<unsigned char>(bits | 0x80))
+        bits = enc & 0x7f
+        enc >>= 7
         idx += 1
 
-    buf.append(<unsigned char>varint)
+    buf.append(<unsigned char>bits)
     return idx + 1
 
 
@@ -190,14 +195,19 @@ cdef int set_signed_varint64(int64_t varint, bytearray buf):
     Serialize an integer into a signed protobuf varint; return the number of
     bytes serialized.
     """
-    varint = (varint << 1) ^ (varint >> 63)
+    cdef uint64_t enc
     cdef int idx = 1
-    while varint >> 7:
-        buf.append(<unsigned char>(varint | 0x80))
-        varint = varint >> 7
+
+    enc = (varint << 1) ^ (varint >> 63) # zigzag encoding
+    bits = enc & 0x7f
+    enc >>= 7
+    while enc:
+        buf.append(<unsigned char>(bits | 0x80))
+        bits = enc & 0x7f
+        enc >>= 7
         idx += 1
 
-    buf.append(<unsigned char>varint)
+    buf.append(<unsigned char>bits)
     return idx + 1
 
 

--- a/tests/proto/test_signed_integer.proto
+++ b/tests/proto/test_signed_integer.proto
@@ -1,0 +1,8 @@
+message Int {
+    optional sint64 Int64 = 1;
+    optional sint32 Int32 = 2;
+    optional uint64 UInt64 = 3;
+    optional uint32 UInt32 = 4;
+    optional sint64 SInt64 = 5;
+    optional sint32 SInt32 = 6;
+}

--- a/tests/test_signed_integer.py
+++ b/tests/test_signed_integer.py
@@ -1,0 +1,58 @@
+import pytest
+from proto_lib_fixture import proto_lib
+import random
+
+
+def gen_rand_int32():
+    return random.randint(-2**31, 2**31-1)
+
+def gen_rand_uint32():
+    return random.randint(0, 2**32-1)
+
+def gen_rand_int64():
+    return random.randint(-2**63, 2**63-1)
+
+def gen_rand_uint64():
+    return random.randint(0, 2**64-1)
+
+def test_int32(proto_lib):
+    from test_signed_integer_proto import Int
+    a = Int()
+    v = gen_rand_int32()
+    a.Int32 = v
+    assert Int.FromString(a.SerializeToString()).Int32 == v
+
+def test_int64(proto_lib):
+    from test_signed_integer_proto import Int
+    a = Int()
+    v = gen_rand_int64()
+    a.Int64 = v
+    assert Int.FromString(a.SerializeToString()).Int64 == v
+
+def test_uint32(proto_lib):
+    from test_signed_integer_proto import Int
+    a = Int()
+    v = gen_rand_uint32()
+    a.UInt32 = v
+    assert Int.FromString(a.SerializeToString()).UInt32 == v
+
+def test_uint64(proto_lib):
+    from test_signed_integer_proto import Int
+    a = Int()
+    v = gen_rand_uint64()
+    a.UInt64 = v
+    assert Int.FromString(a.SerializeToString()).UInt64 == v
+
+def test_sint32(proto_lib):
+    from test_signed_integer_proto import Int
+    a = Int()
+    v = gen_rand_int32()
+    a.SInt32 = v
+    assert Int.FromString(a.SerializeToString()).SInt32 == v
+
+def test_sint64(proto_lib):
+    from test_signed_integer_proto import Int
+    a = Int()
+    v = gen_rand_int64()
+    a.SInt64 = v
+    assert Int.FromString(a.SerializeToString()).SInt64 == v


### PR DESCRIPTION
Hi,

We are using pyrobuf to enhance performance in our project. The speed is fast but we noticed a problem in underlying operation when dealing with variant integers. : (

The current version of `set_signed_varint` will **hang**  sometimes since the right shift to a **negetive** integer will be -1 (the while clause will never terminate).  I have attached a randomized testing to reproduce the situation. As far as I know, the protobuf protocol uses zigtag algorithm to encode a signed value to an unsigned one. So I've made some change to the function (please refer to the code). : )

And a similar problem occurs in the `get_signed_varint` function. I guess we could use the following simple algorithm to decode a zigtag-encoded number back:

 `(value >> 1) ^ (-(value & 1)`

Another obervation is that there are three kinds of integer type in protobuf: int, uint and sint. sint32/sint64 will use the zigzag encoder and sint32/sint64 will use a simple encoder.

And in pyrobuf, sint32/sint64 and int32/int64 will be both compiled to use `set_signed_varint/get_signed_varint` to serialize and deserialize the value. Am I correct?

Best regard
Yichao
