### PR TITLE
handle optional syntax field

### DIFF
--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -21,7 +21,8 @@ class Parser(object):
         'RBRACE': r'\}',
         'SKIP': r'[ \t]',
         'NEWLINE': r'[\r\n]',
-        'PACKAGE': r'package\s.*;'
+        'PACKAGE': r'package\s.*;',
+        'SYNTAX': r'(syntax\s+.*?);'
     }
 
     scalars = (
@@ -106,6 +107,9 @@ class Parser(object):
             if token_type == 'OPTION':
                 yield ParserOption(pos, *vals)
 
+            elif token_type == 'SYNTAX':
+                yield ParserSyntax(pos, *vals)
+
             elif token_type == 'IMPORT':
                 yield ParserImport(pos, *vals)
 
@@ -150,6 +154,12 @@ class Parser(object):
 
         for token in tokens:
             if token.token_type == 'OPTION':
+                continue
+
+            elif token.token_type == 'SYNTAX':
+                if 'proto2' not in token.value:
+                    raise Exception(
+                        'Only proto2 is currently supported')
                 continue
 
             elif token.token_type == 'IMPORT':
@@ -315,6 +325,13 @@ class ParserOption(object):
         self.token_type = 'OPTION'
         self.pos = pos
         self.option = option
+
+
+class ParserSyntax(object):
+    def __init__(self, pos, value):
+        self.token_type = 'SYNTAX'
+        self.pos = pos
+        self.value = value
 
 
 class ParserImport(object):

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,0 +1,44 @@
+import unittest
+
+from pyrobuf.parse_proto import Parser
+
+
+syntax2_explicit = '''
+syntax = "proto2";
+
+message SearchRequest {
+  required string query = 1;
+  optional int32 page_number = 2;
+  optional int32 result_per_page = 3;
+}
+'''
+
+syntax2_implicit = '''
+message SearchRequest {
+  required string query = 1;
+  optional int32 page_number = 2;
+  optional int32 result_per_page = 3;
+}
+'''
+
+syntax3_explicit = '''
+syntax = "proto3";
+
+message SearchRequest {
+  string query = 1;
+  int32 page_number = 2;
+  int32 result_per_page = 3;
+}
+'''
+
+
+class SyntaxTest(unittest.TestCase):
+
+    def test_syntax2(self):
+        parser = Parser()
+        parser.parse(syntax2_implicit)
+        parser.parse(syntax2_explicit)
+
+    def test_syntax3_raises_exception(self):
+        parser = Parser()
+        self.assertRaises(Exception, parser.parse, syntax3_explicit)


### PR DESCRIPTION
This PR attempts to resolve #38.

If the syntax field is present it must be ``proto2``. This allows proto files with the optional syntax field present to continue parsing.

The included test performs simple checks for implicit and explicit declaration of ``syntax = "proto2";`` and checks for an exception being raised if any other proto version is encountered.