### PR TITLE
Fix #41: Add from_varint functions to pyrobuf_util

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ Python dictionaries:
 >>> test.ParseFromDict({'field': 5, 'list_fieldx': [12], 'req_field': 2, 'string_field': 'hello!', 'test_ref': {'field2': 3.14}})
 ```
 
+Finally, the `pyrobuf_util` module contains functions for encoding and decoding integers.
+
+```
+>>> import pyrobuf_util
+>>> pyrobuf_util.to_varint(2**16-1)
+bytearray(b'\xff\xff\x03')
+>>> pyrobuf_util.from_varint(b'\xff\xff\x03', offset=0)
+(65535L, 3)
+>>> pyrobuf_util.to_signed_varint(-2**16)
+bytearray(b'\xff\xff\x07')
+>>> pyrobuf_util.from_signed_varint(b'\xff\xff\x07', offset=0)
+(-65536L, 3)
+```
+
+The `from_varint` and `from_signed_varint` functions return both the decoded integer and
+the offset of the first byte after the encoded integer in the source data.
+
 ### Performance
 
 On my development machine (Ubuntu 14.04), Pyrobuf is roughly 2.0x as fast as

--- a/pyrobuf/src/pyrobuf_util.pyx
+++ b/pyrobuf/src/pyrobuf_util.pyx
@@ -85,6 +85,10 @@ cdef int64_t get_varint64(const unsigned char *varint, int *offset):
             return value
 
 def get_varint(data, offset=0):
+    """
+    Return an integer value obtained by decoding varint data from the given
+    byte string beginning at the specified offset.
+    """
     cdef int _offset = offset
     return get_varint64(data, &_offset)
 
@@ -130,8 +134,12 @@ cdef int64_t get_signed_varint64(const unsigned char *varint, int *offset):
             return <int64_t>((value >> 1) ^ (-(value & 1))) # zigzag decoding
 
 def get_signed_varint(data, offset=0):
+    """
+    Return an integer value obtained by decoding signed-varint data from the
+    given byte string beginning at the specified offset.
+    """
     cdef int _offset = offset
-    return get_varint64(data, &_offset)
+    return get_signed_varint64(data, &_offset)
 
 
 cdef int set_varint32(int32_t varint, bytearray buf):
@@ -175,6 +183,10 @@ cdef int set_varint64(int64_t varint, bytearray buf):
     return idx + 1
 
 def to_varint(varint):
+    """
+    Return a byte string containing the varint encoded form of the specified
+    varint.
+    """
     buf = bytearray()
     set_varint64(varint, buf)
     return buf
@@ -223,6 +235,30 @@ cdef int set_signed_varint64(int64_t varint, bytearray buf):
 
 
 def to_signed_varint(varint):
+    """
+    Return a byte string containing the signed-varint encoded form of the
+    specified varint.
+    """
     buf = bytearray()
     set_signed_varint64(varint, buf)
     return buf
+
+
+def from_varint(data, offset=0):
+    """
+    Return a (integer value, new_offset) pair obtained by decoding varint data
+    from the given byte string beginning at the specified offset.
+    """
+    cdef int _offset = offset
+    result = get_varint64(data, &_offset)
+    return result, _offset
+
+
+def from_signed_varint(data, offset=0):
+    """
+    Return a (integer value, new_offset) pair obtained by decoding signed varint
+    data from the given byte string beginning at the specified offset.
+    """
+    cdef int _offset = offset
+    result = get_signed_varint64(data, &_offset)
+    return result, _offset

--- a/tests/test_varint_encoding.py
+++ b/tests/test_varint_encoding.py
@@ -1,0 +1,147 @@
+import pyrobuf_util
+
+
+def test_varint_encode_0():
+    assert pyrobuf_util.to_varint(0) == b'\x00'
+
+
+def test_varint_encode_1():
+    assert pyrobuf_util.to_varint(1) == b'\x01'
+
+
+def test_varint_encode_12345():
+    assert pyrobuf_util.to_varint(12345) == b'\xb9`'
+
+
+def test_varint_encode_max_int32():
+    assert pyrobuf_util.to_varint(2**31-1) == b'\xff\xff\xff\xff\x07'
+
+
+def test_varint_encode_max_int64():
+    assert pyrobuf_util.to_varint(2**63-1) == b'\xff\xff\xff\xff\xff\xff\xff\xff\x7f'
+
+
+def test_varint_encode_negative_1():
+    assert pyrobuf_util.to_varint(-1) == b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01'
+
+
+def test_varint_encode_negative_12345():
+    assert pyrobuf_util.to_varint(-12345) == b'\xc7\x9f\xff\xff\xff\xff\xff\xff\xff\x01'
+
+
+def test_varint_encode_negative_max_int32():
+    assert pyrobuf_util.to_varint(-2**31) == b'\x80\x80\x80\x80\xf8\xff\xff\xff\xff\x01'
+
+
+def test_varint_encode_negative_max_int64():
+    assert pyrobuf_util.to_varint(-2**63) == b'\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01'
+
+
+def test_varint_decode_0():
+    assert pyrobuf_util.from_varint(b'\x00') == (0, 1)
+
+
+def test_varint_decode_1():
+    assert pyrobuf_util.from_varint(b'\x01') == (1, 1)
+
+
+def test_varint_decode_12345():
+    assert pyrobuf_util.from_varint(b'\xb9`') == (12345, 2)
+
+
+def test_varint_decode_max_int32():
+    assert pyrobuf_util.from_varint(b'\xff\xff\xff\xff\x07') == (2**31-1, 5)
+
+
+def test_varint_decode_max_int64():
+    assert pyrobuf_util.from_varint(b'\xff\xff\xff\xff\xff\xff\xff\xff\x7f') == (2**63-1, 9)
+
+
+def test_varint_decode_negative_1():
+    assert pyrobuf_util.from_varint(b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01') == (-1, 10)
+
+
+def test_varint_decode_negative_12345():
+    assert pyrobuf_util.from_varint(b'\xc7\x9f\xff\xff\xff\xff\xff\xff\xff\x01') == (-12345, 10)
+
+
+def test_varint_decode_negative_max_int32():
+    assert pyrobuf_util.from_varint(b'\x80\x80\x80\x80\xf8\xff\xff\xff\xff\x01') == (-2**31, 10)
+
+
+def test_varint_decode_negative_max_int64():
+    assert pyrobuf_util.from_varint(b'\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01') == (-2**63, 10)
+
+
+# Now for signed varints
+
+def test_signed_varint_encode_0():
+    assert pyrobuf_util.to_signed_varint(0) == b'\x00'
+
+
+def test_signed_varint_encode_1():
+    assert pyrobuf_util.to_signed_varint(1) == b'\x02'
+
+
+def test_signed_varint_encode_12345():
+    assert pyrobuf_util.to_signed_varint(12345) == b'\xf2\xc0\x01'
+
+
+def test_signed_varint_encode_max_int32():
+    assert pyrobuf_util.to_signed_varint(2**31-1) == b'\xfe\xff\xff\xff\x0f'
+
+
+def test_signed_varint_encode_max_int64():
+    assert pyrobuf_util.to_signed_varint(2**63-1) == b'\xfe\xff\xff\xff\xff\xff\xff\xff\xff\x01'
+
+
+def test_signed_varint_encode_negative_1():
+    assert pyrobuf_util.to_signed_varint(-1) == b'\x01'
+
+
+def test_signed_varint_encode_negative_12345():
+    assert pyrobuf_util.to_signed_varint(-12345) == b'\xf1\xc0\x01'
+
+
+def test_signed_varint_encode_negative_max_int32():
+    assert pyrobuf_util.to_signed_varint(-2**31) == b'\xff\xff\xff\xff\x0f'
+
+
+def test_signed_varint_encode_negative_max_int64():
+    assert pyrobuf_util.to_signed_varint(-2**63) == b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01'
+
+
+def test_signed_varint_decode_0():
+    assert pyrobuf_util.from_signed_varint(b'\x00') == (0, 1)
+
+
+def test_signed_varint_decode_1():
+    assert pyrobuf_util.from_signed_varint(b'\x02') == (1, 1)
+
+
+def test_signed_varint_decode_12345():
+    assert pyrobuf_util.from_signed_varint(b'\xf2\xc0\x01') == (12345, 3)
+
+
+def test_signed_varint_decode_max_int32():
+    assert pyrobuf_util.from_signed_varint(b'\xfe\xff\xff\xff\x0f') == (2**31-1, 5)
+
+
+def test_signed_varint_decode_max_int64():
+    assert pyrobuf_util.from_signed_varint(b'\xfe\xff\xff\xff\xff\xff\xff\xff\xff\x01') == (2**63-1, 10)
+
+
+def test_signed_varint_decode_negative_1():
+    assert pyrobuf_util.from_signed_varint(b'\x01') == (-1, 1)
+
+
+def test_signed_varint_decode_negative_12345():
+    assert pyrobuf_util.from_signed_varint(b'\xf1\xc0\x01') == (-12345, 3)
+
+
+def test_signed_varint_decode_negative_max_int32():
+    assert pyrobuf_util.from_signed_varint(b'\xff\xff\xff\xff\x0f') == (-2**31, 5)
+
+
+def test_signed_varint_decode_negative_max_int64():
+    assert pyrobuf_util.from_signed_varint(b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01') == (-2**63, 10)


### PR DESCRIPTION
This PR adds two new functions to pyrobuf_util:

- `from_varint(data, offset=0)` -- returns a (integer value, new offset) pair obtained by decoding the varint encoded integer in the supplied byte string beginning at the specified offset
- `from_signed_varint(data, offset=0)` -- returns a (integer value, new offset) pair obtained by decoding the signed-varint encoded integer in the supplied byte string beginning at the specified offset

I've also added some documentation to README.md concerning the `to_varint`, `to_signed_varint`, `from_varint` and `from_signed_varint` functions.