### PR TITLE
Fix Python 2.7 problem and document the pyrobuf_modules setup keyword 

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,44 @@ bytearray(b'\xff\xff\x07')
 The `from_varint` and `from_signed_varint` functions return both the decoded integer and
 the offset of the first byte after the encoded integer in the source data.
 
+### Distributing a Python Package with Pyrobuf Modules
+
+Suppose you have a Python package called 'sample' arranged on disk as follows:
+
+```
+sample/
+    proto/
+        my_message.proto
+    sample/
+        __init__.py
+    setup.py
+```
+
+Pyrobuf adds a new setup keyword `pyrobuf_modules` which can be used to specify either
+individual protobuf files or folders containing protobuf files. For example, the `setup.py`
+file could look like this:
+ 
+```
+from setuptools import setup, find_packages
+
+setup(
+    name="sample",
+    version="0.1",
+    packages=find_packages(),
+    description="A sample package",
+    install_requires=['pyrobuf'],
+    setup_requires=['pyrobuf'],
+    pyrobuf_modules="proto"
+)
+```
+
+Once installed this sample package can be used as follows:
+
+```
+>>> import sample
+>>> import my_message_proto
+```
+
 ### Performance
 
 On my development machine (Ubuntu 14.04), Pyrobuf is roughly 2.0x as fast as

--- a/pyrobuf/setuptools_ext.py
+++ b/pyrobuf/setuptools_ext.py
@@ -16,7 +16,6 @@ except NameError:
 
 
 def add_pyrobuf_module(dist, pyrobuf_module):
-    print "ADD_PYROBUF_MODULE CALLED WITH", pyrobuf_module
     parser = Parser()
 
     env = Environment(loader=PackageLoader('pyrobuf.protobuf', 'templates'))

--- a/pyrobuf/setuptools_ext.py
+++ b/pyrobuf/setuptools_ext.py
@@ -1,6 +1,7 @@
 """Setuptools integration."""
 import glob
 import os
+import os.path
 
 from Cython.Build import cythonize
 from jinja2 import Environment, PackageLoader
@@ -15,6 +16,7 @@ except NameError:
 
 
 def add_pyrobuf_module(dist, pyrobuf_module):
+    print "ADD_PYROBUF_MODULE CALLED WITH", pyrobuf_module
     parser = Parser()
 
     env = Environment(loader=PackageLoader('pyrobuf.protobuf', 'templates'))
@@ -23,7 +25,8 @@ def add_pyrobuf_module(dist, pyrobuf_module):
 
     dir_name = "pyrobuf/_" + pyrobuf_module
 
-    os.makedirs(dir_name, exist_ok=True)
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
 
     if os.path.isdir(pyrobuf_module):
         for spec in glob.glob(os.path.join(pyrobuf_module, '*.proto')):


### PR DESCRIPTION
This PR removes a Python 2.7 incompatible reference to the 'exist_ok' keyword argument to `os.makedirs` in `setuptools_ext.py`. It also adds a new section to the README.md file documenting the `pyrobuf_modules` setup keyword with a simple example.