### PR TITLE
set minimum jinja2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
     url='https://github.com/appnexus/pyrobuf',
     author='AppNexus',
     tests_require=['pytest'] + (['protobuf >= 2.6.0, <3'] if sys.version_info.major == 2 else []),
-    setup_requires=['jinja2', 'cython >= 0.23', 'pytest-runner'],
-    install_requires=['jinja2', 'cython >= 0.23'],
+    setup_requires=['jinja2 >= 2.8', 'cython >= 0.23', 'pytest-runner'],
+    install_requires=['jinja2 >= 2.8', 'cython >= 0.23'],
     zip_safe=False,
 )


### PR DESCRIPTION
Just ran into the following exception installing Pyrobuf on a dev server running Ubuntu 14.04:
```jinja2.exceptions.TemplateRuntimeError: no test named 'equalto'```
Noticed that the Jinja2 version was 2.7.2 versus 2.8.0 on my local machine and upgrading fixed the problem.