### PR TITLE
Fix #48. Support any iterable in list extend methods

### DIFF
--- a/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pxd.tmpl
@@ -38,7 +38,7 @@ cdef class {{ name }}:
     cdef void _append(self, {{ type }} x)
 
     cpdef append(self, {{ type }} x)
-    cpdef extend(self, {{ name }} x)
+    cpdef extend(self, x)
     cpdef insert(self, int i, {{ type }} x)
     cpdef pop(self)
     cpdef remove(self, {{ type }} x)

--- a/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/pyrobuf_list_pyx.tmpl
@@ -72,13 +72,11 @@ cdef class TypedList(list):
             listener._Modified()
 
     def extend(self, x):
-        try:
-            assert isinstance(x, TypedList)
-            assert self._list_type == x.list_type
-        except AssertionError:
-            raise Exception("type mismatch")
+        for i in x:
+            elt = self._list_type()
+            elt.MergeFrom(i)
+            super(TypedList, self).append(elt)
 
-        super(TypedList, self).extend(x)
         listener = <object>self._listener
         if not listener._is_present_in_parent:
             listener._Modified()
@@ -429,29 +427,13 @@ cdef class {{ name }}:
         if not listener._is_present_in_parent:
             listener._Modified()
 
-    cpdef extend(self, {{ name }} x):
-        cdef {{ type }} *mem
-        cdef size_t new_len = self._n_items + len(x)
-        cdef size_t new_size
-        cdef int i
+    cpdef extend(self, x):
+        for i in x:
+            self._append(i)
 
-        if new_len > self._size:
-            new_size = max(new_len, 2 * self._size)
-            mem = <{{ type }} *>PyMem_Realloc(self._data, new_size * sizeof({{ type }}))
-            if not mem:
-                raise MemoryError()
-
-            self._data = mem
-            self._size = new_size
-
-        for i in range(len(x)):
-            self._data[self._n_items + i] = x[i]
-
-        if new_len != self._n_items:
-            listener = <object>self._listener
-            if not listener._is_present_in_parent:
-                listener._Modified()
-        self._n_items = new_len
+        listener = <object>self._listener
+        if not listener._is_present_in_parent:
+            listener._Modified()
 
     cpdef insert(self, int i, {{ type }} x):
         cdef {{ type }} *mem

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -2,6 +2,7 @@ import unittest
 
 from pyrobuf_list import *
 
+
 class DoubleListTest(unittest.TestCase):
 
     def test_append_get_set_len(self):
@@ -78,6 +79,16 @@ class DoubleListTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             x.remove(7)
+
+    def test_extend_with_generic_list(self):
+        x1 = DoubleList()
+        x2 = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+        x1.extend(x2)
+
+        for i in range(5):
+            self.assertEqual(x1[i], x2[i])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_typed_lists.py
+++ b/tests/test_typed_lists.py
@@ -1,0 +1,42 @@
+import unittest
+
+import pytest
+from proto_lib_fixture import proto_lib
+
+
+Test = None
+TestRef = None
+
+
+@pytest.mark.usefixtures('proto_lib')
+class MergeFromTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        global Test, TestRef
+        from test_message_proto import Test
+        from test_ref_message_proto import TestRef
+
+    def test_extend_with_generic_list(self):
+        t = Test()
+        refs = [TestRef(), TestRef(), TestRef()]
+
+        for i in range(3):
+            refs[i].field1 = i
+
+        t.list_ref.extend(refs)
+
+        for i in range(3):
+            self.assertEqual(t.list_ref[i].field1, i)
+            self.assertIsNot(t.list_ref[i], refs[i])
+
+    def test_set_list_with_keyword_arg(self):
+        refs = [TestRef(), TestRef(), TestRef()]
+
+        for i in range(3):
+            refs[i].field1 = i
+
+        t = Test(list_ref=refs)
+
+        for i in range(3):
+            self.assertEqual(t.list_ref[i].field1, i)
+            self.assertIsNot(t.list_ref[i], refs[i])


### PR DESCRIPTION
Previously the TypedList `extend` method would only work if given another TypedList (with the same list type) as an argument. Similarly the `extend` method of scalar lists would only work if given another scalar list of the same type. This PR makes the list extend methods work with any iterable as long as its elements are of the appropriate type.

This PR also fixes a subtle bug in the TypedList `extend` method which would cause the extended list to have references to the elements of the iterable rather than copies of them as the [protobuf semantics require](https://developers.google.com/protocol-buffers/docs/reference/python-generated#repeated-message-fields).