### PR TITLE
Turns out Pyrobuf fails to compile messages with repeated enum fields…

### DIFF
--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -278,8 +278,6 @@ cdef class {{ name }}:
         cdef {% if version_major == 2 %}unicode{% else %}str{% endif %} {{ field.name }}_elt
             {%- elif field.type == 'bytes' %}
         cdef bytes {{ field.name }}_elt
-            {%- elif field.type == 'enum' %}
-        cdef int32_t {{ field.name }}_elt
             {%- else  %}
         cdef {{ field.c_type }} {{ field.name }}_elt
             {%- endif %}
@@ -645,8 +643,6 @@ cdef class {{ name }}:
         cdef bytearray {{ field.name }}_elt_buf
             {%- elif field.type == 'string' %}
         cdef bytes {{ field.name }}_elt
-            {%- elif field.type == 'enum' %}
-        cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }} {{ field.name }}_elt
             {%- else %}
         cdef {{ field.c_type }} {{ field.name }}_elt
             {%- endif %}

--- a/tests/proto/test_repeated_enum.proto
+++ b/tests/proto/test_repeated_enum.proto
@@ -1,0 +1,8 @@
+message TestRepeatedEnum {
+    enum EnumField {
+        TEST_ENUM_FIELD_0 = 0;
+        TEST_ENUM_FIELD_1 = 1;
+        TEST_ENUM_FIELD_2 = 2;
+    }
+    repeated EnumField list_enum = 1;
+}

--- a/tests/test_repeated_enum.py
+++ b/tests/test_repeated_enum.py
@@ -1,0 +1,32 @@
+import unittest
+
+import pytest
+from proto_lib_fixture import proto_lib
+
+TestRepeatedEnum = None
+
+
+@pytest.mark.usefixtures('proto_lib')
+class RepeatedEnumTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        global TestRepeatedEnum
+        from test_repeated_enum_proto import TestRepeatedEnum
+
+    def test_repeated_enum_serde(self):
+        message1 = TestRepeatedEnum()
+        message2 = TestRepeatedEnum()
+
+        message1.list_enum.append(2)
+        message1.list_enum.append(0)
+        message1.list_enum.append(1)
+
+        buf = message1.SerializeToString()
+        message2.ParseFromString(buf)
+
+        for i in range(len(message1.list_enum)):
+            self.assertEqual(message1.list_enum[i], message2.list_enum[i])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
… - fixed this and added a unit test

Note: we also don't currently do any checking on repeated enum fields when appending to ensure that they are valid values, but that's maybe a PR unto itself.