### PR TITLE
Minor parse_proto.py typo fix

### DIFF
--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -180,7 +180,7 @@ class Parser(object):
                 enums[token.name] = token
 
             else:
-                raise Exception("unexpected %s token at character %d: '%s'" % (token.typ, token.pos, s[token.pos:token.pos+10]))
+                raise Exception("unexpected %s token at character %d: '%s'" % (token.type, token.pos, s[token.pos:token.pos+10]))
 
         if cython_info:
             for message in rep['messages']:


### PR DESCRIPTION
This was leading to a
```
AttributeError: 'ParserField' object has no attribute 'typ'
```