### PR TITLE
Differentiate between nested enums with the same names

### DIFF
--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -174,7 +174,7 @@ class Parser(object):
                 imported['enums'].update((e.name, e) for e in imported_rep['enums'])
 
             elif token.token_type == 'MESSAGE':
-                rep['messages'].append(self._parse_message(s, token, tokens, messages, enums, imported['enums']))
+                rep['messages'].append(self._parse_message(s, token, tokens, messages, enums.copy(), imported['enums']))
 
             elif token.token_type == 'ENUM':
                 ret = self._parse_enum(s, token, tokens)
@@ -214,17 +214,22 @@ class Parser(object):
             enums: {string: ParserEnum} dictionary.
         """
         if token.default is not None:
+            found = False
             for entry in enums[token.type].fields:
                 if token.default == entry.name:
                     default = entry.value
-                    enum_default = entry.name
+                    enum_default = entry.full_name
+                    found = True
                     break
 
-            token.default = default
-            token.enum_default = enum_default
+            if found:
+                token.default = default
+                token.enum_default = enum_default
+            else:
+                raise Exception('Enum type "%s" has no value named "%s".' % (token.type, token.default))
 
         token.enum_def = enums[token.type]
-        token.enum_name = token.type
+        token.enum_name = token.enum_def.full_name
         token.type = 'enum'
 
     def _parse_message(self, s, current, tokens, messages, enums, imported_enums):
@@ -249,11 +254,12 @@ class Parser(object):
         for token in tokens:
             if token.token_type == 'MESSAGE':
                 token.full_name = current.full_name + token.name
-                current.messages[token.name] = self._parse_message(s, token, tokens, messages, enums, imported_enums)
+                current.messages[token.name] = self._parse_message(s, token, tokens, messages, enums.copy(), imported_enums)
                 # updates the dictionary of known/parsed messages.
                 messages[token.name] = current.messages[token.name]
 
             elif token.token_type == 'ENUM':
+                token.full_name = current.full_name + token.name
                 current.enums[token.name] = self._parse_enum(s, token, tokens)
                 # updates the dictionary of known/parsed enums
                 enums[token.name] = current.enums[token.name]
@@ -296,6 +302,7 @@ class Parser(object):
 
         for token in tokens:
             if token.token_type == 'ENUM_FIELD':
+                token.full_name = "%s_%s" % (current.full_name, token.name)
                 current.fields.append(token)
 
             elif token.token_type == 'RBRACE':
@@ -410,6 +417,8 @@ class ParserEnum(object):
         self.pos = pos
         self.name = name
         self.fields = []
+        # full_name may later be overriden with parent hierarchy when relevant
+        self.full_name = name
 
 
 class ParserEnumField(object):
@@ -421,6 +430,8 @@ class ParserEnumField(object):
             self.value = int(value, 0)
         else:
             self.value = None
+        # full_name may later be overriden with parent hierarchy when relevant
+        self.full_name = name
 
 
 class ParserLBrace(object):

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -24,9 +24,9 @@ cdef class {{ message.full_name }}:
     {%- elif field.type == 'bytes' %}
     cdef bytes _{{ field.name }}
     {%- elif field.type == 'message' %}
-    cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.message_name }} _{{ field.name }}
+    cdef {{ field.message_name }} _{{ field.name }}
     {%- elif field.type == 'enum' %}
-    cdef {% if field.is_nested %}{{ name }}{% endif %}{{ field.enum_name }} _{{ field.name }}
+    cdef _{{ field.enum_name }} _{{ field.name }}
     {%- else %}
     cdef {{ field.c_type }} _{{ field.name }}
     {%- endif %}
@@ -59,7 +59,7 @@ cdef class {{ message.full_name }}:
     cpdef void _Modified(self)
 
     {%- for enum_name, enum in message.enums.items() %}
-{{ enumdef(enum_name, enum) }}
+{{ enumdef(enum.full_name, enum) }}
     {%- endfor %}
 
     {%- for submessage_name, submessage in message.messages.items() %}
@@ -69,14 +69,14 @@ cdef class {{ message.full_name }}:
 {%- endmacro %}
 
 {%- macro enumdef(name, enum) %}
-cdef enum {{ name }}:
+cdef enum _{{ name }}:
     {%- for field in enum.fields %}
-    _{{ field.name }} = {{ field.value }}
+    _{{ field.full_name }} = {{ field.value }}
     {%- endfor %}
 {%- endmacro %}
 
 {%- for enum in enums %}
-{{ enumdef(enum.name, enum) }}
+{{ enumdef(enum.full_name, enum) }}
 {%- endfor %}
 
 {%- for message in messages %}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -14,7 +14,7 @@ from {{ import }}_proto cimport *
 
 {%- macro message_enum_fields_def(enum) %}
     {%- for field in enum.fields %}
-    {{ field.name }} = _{{ field.name }}
+    {{ field.name }} = _{{ field.full_name }}
     {%- endfor %}
 {%- endmacro %}
 
@@ -124,7 +124,7 @@ cdef class {{ message.full_name }}:
         {%- elif field.type == 'bytes' %}
         self._{{ field.name }} = b""
         {%- elif field.type == 'enum' and field.enum_def != None %}
-        self._{{ field.name }} = _{{ field.enum_def.fields[0].name }}
+        self._{{ field.name }} = _{{ field.enum_def.fields[0].full_name }}
         {%- else %}
         self._{{ field.name }} = 0
         {%- endif %}
@@ -184,7 +184,7 @@ cdef class {{ message.full_name }}:
                     {%- else %}
                 elif val == {{ enum_field.value }}:
                     {%- endif %}
-                    self._{{ field.name }}.append(_{{ enum_field.name }})
+                    self._{{ field.name }}.append(_{{ enum_field.full_name }})
                 {% endfor %}
                 else:
                     raise ValueError("not a valid value for enum {{ field.enum_name }}")
@@ -220,7 +220,7 @@ cdef class {{ message.full_name }}:
                     {%- else %}
             elif value == {{ enum_field.value }}:
                     {%- endif %}
-                self._{{ field.name }} = _{{ enum_field.name }}
+                self._{{ field.name }} = _{{ enum_field.full_name }}
                 {% endfor %}
             else:
                 raise ValueError("not a valid value for enum {{ field.enum_name }}")
@@ -434,7 +434,7 @@ cdef class {{ message.full_name }}:
             {%- elif field.type == 'bytes' %}
             self._{{ field.name }} = b""
             {%- elif field.type == 'enum' and field.enum_def != None %}
-            self._{{ field.name }} = _{{ field.enum_def.fields[0].name }}
+            self._{{ field.name }} = _{{ field.enum_def.fields[0].full_name }}
             {%- else %}
             self._{{ field.name }} = 0
             {%- endif %}
@@ -971,7 +971,7 @@ class DecodeError(Exception):
 
 {%- macro enum_fields_def(enum) %}
 {%- for field in enum.fields %}
-{{ field.name }} = _{{ field.name }}
+{{ field.name }} = _{{ field.full_name }}
 {%- endfor %}
 {%- endmacro %}
 

--- a/tests/proto/test_enum_conflicts.proto
+++ b/tests/proto/test_enum_conflicts.proto
@@ -1,0 +1,29 @@
+enum TestEnum {
+    TEST_VALUE0 = 0;
+    TEST_VALUE1 = 1;
+    TEST_VALUE2 = 2;
+}
+
+message TestMessage {
+    enum TestEnum {
+        TEST_VALUE1 = 3;
+        TEST_VALUE2 = 4;
+        TEST_VALUE3 = 5;
+    }
+
+    message TestNestedMessage {
+        enum TestEnum {
+            TEST_VALUE1 = 6;
+            TEST_VALUE2 = 7;
+            TEST_VALUE4 = 9;
+        }
+
+        optional TestEnum test_field = 1 [default=TEST_VALUE4];
+    }
+
+    optional TestEnum test_field = 1 [default=TEST_VALUE3];
+}
+
+message TestMessage2 {
+    optional TestEnum test_field = 1 [default=TEST_VALUE0];
+}


### PR DESCRIPTION
Following on from @AndreMiras's [pull request 68 ](https://github.com/appnexus/pyrobuf/pull/68), this pull request causes pyrobuf to differentiate between nested enums with the same name. For example:

```protobuf
enum TestEnum {
    TEST_VALUE = 1;
}

message TestMessage {
    enum TestEnum {
        TEST_VALUE = 1;
    }

    optional TestEnum test_field = 1;
}

message TestMessage2 {
    optional TestEnum test_field = 1;
}
```