### PR TITLE
Parse unrecognized fields to update offset correctly when deserializing

### DIFF
--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -192,7 +192,7 @@ cdef class {{ message.full_name }}:
                     self._{{ field.name }}.append(_{{ enum_field.full_name }})
                 {% endfor %}
                 else:
-                    raise ValueError("not a valid value for enum {{ field.enum_name }}")
+                    raise ValueError("{} not a valid value for enum {{ field.enum_name }}".format(val))
             {%- elif field.type == 'string' and version_major == 2 %}
                 if isinstance(val, unicode):
                     list.append(self._{{ field.name }}, val)
@@ -228,7 +228,7 @@ cdef class {{ message.full_name }}:
                 self._{{ field.name }} = _{{ enum_field.full_name }}
                 {% endfor %}
             else:
-                raise ValueError("not a valid value for enum {{ field.enum_name }}")
+                raise ValueError("{} not a valid value for enum {{ field.enum_name }}".format(value))
             {%- elif field.type == 'string' and version_major == 2 %}
             if isinstance(value, unicode):
                 self._{{ field.name }} = value
@@ -382,8 +382,10 @@ cdef class {{ message.full_name }}:
                 self._{{ field.name }} = {{ field.getter }}(memory, &current_offset)
 
         {%- endif %}
-
     {%- endfor %}
+            # Unknown field - need to skip proper number of bytes
+            else:
+                assert skip_generic(memory, &current_offset, size, key & 0x7)
     {%- endif %}
 
         self._is_present_in_parent = True

--- a/pyrobuf/src/pyrobuf_util.pxd
+++ b/pyrobuf/src/pyrobuf_util.pxd
@@ -19,3 +19,5 @@ cdef int set_varint64(int64_t varint, bytearray buf)
 cdef int set_signed_varint32(int32_t varint, bytearray buf)
 
 cdef int set_signed_varint64(int64_t varint, bytearray buf)
+
+cdef bint skip_generic(const unsigned char *memory, int *offset, int size, int wire_type)

--- a/pyrobuf/src/pyrobuf_util.pyx
+++ b/pyrobuf/src/pyrobuf_util.pyx
@@ -285,4 +285,3 @@ cdef bint skip_generic(const unsigned char *memory, int *offset, int size, int w
         return False
 
     return offset[0] <= size
-

--- a/pyrobuf/src/pyrobuf_util.pyx
+++ b/pyrobuf/src/pyrobuf_util.pyx
@@ -264,3 +264,25 @@ def from_signed_varint(data, offset=0):
     cdef int _offset = offset
     result = get_signed_varint64(data, &_offset)
     return result, _offset
+
+
+cdef bint skip_generic(const unsigned char *memory, int *offset, int size, int wire_type):
+    """
+    Parse field of given wire type to update offset.
+    """
+    cdef int64_t skip
+
+    if wire_type == 0:
+        get_varint64(memory, offset)
+    elif wire_type == 1:
+        offset[0] += 8
+    elif wire_type == 2:
+        skip = get_varint64(memory, offset)
+        offset[0] += skip
+    elif wire_type == 5:
+        offset[0] += 4
+    else:
+        return False
+
+    return offset[0] <= size
+

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import platform
 import sys
 
 
-VERSION = "0.6.1"
+VERSION = "0.6.2"
 HERE = os.path.dirname(os.path.abspath(__file__))
 PYROBUF_DEFS_PXI = "pyrobuf_defs.pxi"
 PYROBUF_LIST_PXD = "pyrobuf_list.pxd"

--- a/tests/proto/test_truncated.proto
+++ b/tests/proto/test_truncated.proto
@@ -1,0 +1,5 @@
+message TestTruncated {
+    optional uint32 timestamp = 1;
+    required int64 req_field = 10;
+    optional int32 negative_32 = 11;
+}

--- a/tests/test_unknown_field.py
+++ b/tests/test_unknown_field.py
@@ -1,0 +1,26 @@
+import unittest
+
+from test_truncated_proto import TestTruncated
+
+
+GOOGLE_SERIALIZED_MESSAGE = b'\x08\x80\x89\x9a\x81\x02\x10\xc1S\x1a\tgo goats! \x00 d \xc8\x01 ' \
+    b'\xac\x02 \x90\x03*A\x08\xb9`\x12\x05hello\x1a\x12\tH\xe1z\x14\xae.\x96@\x12\x07goodbye!\xd7' \
+    b'\xa3p=\n/v@*\r\tn\x86\x1b\xf0\xf9!\t@\x12\x02pi2\tsomething2\x17\x08\x80\x89\x9a\x81\x02\x10' \
+    b'\xd7\x08\x19\x8d\x97n\x12\x83\xc0\xf3?"\x03fooB\x17\x08\x80\x89\x9a\x81\x02\x10\xd7\x08\x19' \
+    b'\x8d\x97n\x12\x83\xc0\xf3?"\x03fooJ7\n\nwhat\'s up?\x12\x0cnothing much\x18\x18 W*\x17\x08' \
+    b'\x80\x89\x9a\x81\x02\x10\xd7\x08\x19\x8d\x97n\x12\x83\xc0\xf3?"\x03fooP\xee\x87\xfb\xff\xff' \
+    b'\xff\xff\xff\xff\x01X\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01'
+
+
+class MessageTest(unittest.TestCase):
+
+    def test_deser(self):
+        test = TestTruncated()
+        parsed = test.ParseFromString(GOOGLE_SERIALIZED_MESSAGE)
+        self.assertEqual(parsed, len(GOOGLE_SERIALIZED_MESSAGE))
+        self.assertEqual(test.req_field, -80914)
+        self.assertEqual(test.negative_32, -1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Currently, if we encounter a key in a serialized message with an unknown index, we just ignore it and skip to the next byte, but this is incorrect; we actually need to skip over the size of the field.