### PR TITLE
fixed setuptools extension

### DIFF
--- a/pyrobuf/setuptools_ext.py
+++ b/pyrobuf/setuptools_ext.py
@@ -21,6 +21,8 @@ def add_pyrobuf_module(dist, pyrobuf_module):
     env = Environment(loader=PackageLoader('pyrobuf.protobuf', 'templates'))
     templ_pxd = env.get_template('proto_pxd.tmpl')
     templ_pyx = env.get_template('proto_pyx.tmpl')
+    generated = set()
+    pyx_files = []
 
     dir_name = "pyrobuf/_" + pyrobuf_module
 
@@ -29,10 +31,9 @@ def add_pyrobuf_module(dist, pyrobuf_module):
 
     if os.path.isdir(pyrobuf_module):
         for spec in glob.glob(os.path.join(pyrobuf_module, '*.proto')):
-            generate(spec, dir_name, parser, templ_pxd, templ_pyx)
+            generate(spec, dir_name, parser, templ_pxd, templ_pyx, generated, pyx_files)
 
         _, name = os.path.split(pyrobuf_module)
-        pyx = os.path.join(dir_name, '*.pyx')
 
     else:
         name, _ = os.path.splitext(os.path.basename(pyrobuf_module))
@@ -40,13 +41,11 @@ def add_pyrobuf_module(dist, pyrobuf_module):
             print("not a .proto file")
             return
 
-        generate(pyrobuf_module, dir_name, parser, templ_pxd, templ_pyx)
-
-        pyx = os.path.join(dir_name, "%s_proto.pyx" % name)
+        generate(pyrobuf_module, dir_name, parser, templ_pxd, templ_pyx, generated, pyx_files)
 
     if dist.ext_modules is None:
         dist.ext_modules = []
-    dist.ext_modules.extend(cythonize([pyx],
+    dist.ext_modules.extend(cythonize(pyx_files,
                             include_path=[os.path.join(HERE, 'src'), dir_name]))
 
 


### PR DESCRIPTION
I have fixed the problem with using `pyrobuf` in `setup.py`. I was failing because of changes in the `generate` function arguments.

Example:

```
Traceback (most recent call last):
  File "setup.py", line 74, in <module>
    author_email='chwalisz@tkn.tu-berlin.de'
  File "/usr/lib/python3.6/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/home/chwalisz/Code/package/.venv_temp/lib/python3.6/site-packages/setuptools/dist.py", line 318, in __init__
    _Distribution.__init__(self, attrs)
  File "/usr/lib/python3.6/distutils/dist.py", line 281, in __init__
    self.finalize_options()
  File "/home/chwalisz/Code/package/.venv_temp/lib/python3.6/site-packages/setuptools/dist.py", line 376, in finalize_options
    ep.load()(self, ep.name, value)
  File "/home/chwalisz/Code/package/.venv_temp/lib/python3.6/site-packages/pyrobuf/setuptools_ext.py", line 59, in pyrobuf_modules
    add_pyrobuf_module(dist, pyrobuf_module)
  File "/home/chwalisz/Code/package/.venv_temp/lib/python3.6/site-packages/pyrobuf/setuptools_ext.py", line 32, in add_pyrobuf_module
    generate(spec, dir_name, parser, templ_pxd, templ_pyx)
TypeError: generate() missing 2 required positional arguments: 'generated' and 'pyx_files'
```

this part of the project is not tested, so it didn't pop up.