### PR TITLE
Unable to override class `ParserField` and `ParserFieldDeprecated` for proto3

### DIFF
--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -100,6 +100,7 @@ class Parser(object):
     def tokenize(self, s):
         pos = 0
         line = 1
+        _P = self.__class__
 
         m = self.get_token(s, pos)
         while m is not None:
@@ -108,37 +109,37 @@ class Parser(object):
             vals = subm.groups()
 
             if token_type == 'OPTION':
-                yield ParserOption(pos, *vals)
+                yield _P.ParserOption(pos, *vals)
 
             elif token_type == 'SYNTAX':
-                yield ParserSyntax(pos, *vals)
+                yield _P.ParserSyntax(pos, *vals)
 
             elif token_type == 'IMPORT':
-                yield ParserImport(pos, *vals)
+                yield _P.ParserImport(pos, *vals)
 
             elif token_type == 'MESSAGE':
-                yield ParserMessage(pos, *vals)
+                yield _P.ParserMessage(pos, *vals)
 
             elif token_type in ('FIELD', 'FIELD_WITH_DEFAULT'):
-                yield ParserField(pos, *vals)
+                yield _P.ParserField(pos, *vals)
 
             elif token_type == 'FIELD_PACKED':
-                yield ParserFieldPacked(pos, *vals)
+                yield _P.ParserFieldPacked(pos, *vals)
 
             elif token_type == 'FIELD_DEPRECATED':
-                yield ParserFieldDeprecated(pos, *vals)
+                yield _P.ParserFieldDeprecated(pos, *vals)
 
             elif token_type == 'ENUM':
-                yield ParserEnum(pos, *vals)
+                yield _P.ParserEnum(pos, *vals)
 
             elif token_type in ('ENUM_FIELD', 'ENUM_FIELD_WITH_VALUE'):
-                yield ParserEnumField(pos, *vals)
+                yield _P.ParserEnumField(pos, *vals)
 
             elif token_type == 'LBRACE':
-                yield ParserLBrace(pos)
+                yield _P.ParserLBrace(pos)
 
             elif token_type == 'RBRACE':
-                yield ParserRBrace(pos)
+                yield _P.ParserRBrace(pos)
 
             elif token_type == 'NEWLINE':
                 line += 1

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -331,51 +331,114 @@ class Parser(object):
             self.add_cython_info(submessage)
 
 
-class ParserOption(object):
-    def __init__(self, pos, option):
-        self.token_type = 'OPTION'
-        self.pos = pos
-        self.option = option
+    class ParserOption(object):
+        def __init__(self, pos, option):
+            self.token_type = 'OPTION'
+            self.pos = pos
+            self.option = option
 
 
-class ParserSyntax(object):
-    def __init__(self, pos, value):
-        self.token_type = 'SYNTAX'
-        self.pos = pos
-        self.value = value
+    class ParserSyntax(object):
+        def __init__(self, pos, value):
+            self.token_type = 'SYNTAX'
+            self.pos = pos
+            self.value = value
 
 
-class ParserImport(object):
-    def __init__(self, pos, value):
-        self.token_type = 'IMPORT'
-        self.pos = pos
-        self.value = value
+    class ParserImport(object):
+        def __init__(self, pos, value):
+            self.token_type = 'IMPORT'
+            self.pos = pos
+            self.value = value
 
 
-class ParserMessage(object):
-    def __init__(self, pos, name):
-        self.token_type = 'MESSAGE'
-        self.pos = pos
-        self.name = name
-        # full_name may later be overriden with parent hierarchy when relevant
-        self.full_name = name
-        self.messages = {}
-        self.enums = {}
-        self.fields = []
+    class ParserMessage(object):
+        def __init__(self, pos, name):
+            self.token_type = 'MESSAGE'
+            self.pos = pos
+            self.name = name
+            # full_name may later be overriden with parent hierarchy when relevant
+            self.full_name = name
+            self.messages = {}
+            self.enums = {}
+            self.fields = []
 
 
-class ParserField(object):
-    def __init__(self, pos, modifier, ftype, name, index, default=None):
-        self.token_type = 'FIELD'
-        self.pos = pos
-        self.modifier = modifier
-        self.type = ftype
-        self.name = name
-        self.index = int(index)
-        self.default = process_default(default)
-        self.packed = False
-        self.deprecated = False
+    class ParserField(object):
+        def __init__(self, pos, modifier, ftype, name, index, default=None):
+            self.token_type = 'FIELD'
+            self.pos = pos
+            self.modifier = modifier
+            self.type = ftype
+            self.name = name
+            self.index = int(index)
+            self.default = process_default(default)
+            self.packed = False
+            self.deprecated = False
 
+
+
+
+
+    class ParserFieldPacked(object):
+        def __init__(self, pos, modifier, ftype, name, index):
+            self.token_type = 'FIELD'
+            self.pos = pos
+            self.modifier = modifier
+            self.type = ftype
+            self.name = name
+            self.index = int(index)
+            self.default = None
+            self.packed = True
+            self.deprecated = False
+
+
+    class ParserFieldDeprecated(object):
+        def __init__(self, pos, modifier, ftype, name, index):
+            self.token_type = 'FIELD'
+            self.pos = pos
+            self.modifier = modifier
+            self.type = ftype
+            self.name = name
+            self.index = int(index)
+            self.default = None
+            self.packed = False
+            self.deprecated = True
+
+
+    class ParserEnum(object):
+        def __init__(self, pos, name):
+            self.token_type = 'ENUM'
+            self.pos = pos
+            self.name = name
+            self.fields = []
+            # full_name may later be overriden with parent hierarchy when relevant
+            self.full_name = name
+
+
+    class ParserEnumField(object):
+        def __init__(self, pos, name, value=None):
+            self.token_type = 'ENUM_FIELD'
+            self.pos = pos
+            self.name = name
+            if value is not None:
+                self.value = int(value, 0)
+            else:
+                self.value = None
+            # full_name may later be overriden with parent hierarchy when relevant
+            self.full_name = name
+
+
+    class ParserLBrace(object):
+        def __init__(self, pos):
+            self.token_type = 'LBRACE'
+            self.pos = pos
+
+
+    class ParserRBrace(object):
+        def __init__(self, pos):
+            self.token_type = 'RBRACE'
+            self.pos = pos
 
 def process_default(default):
     if default == 'true':
@@ -384,65 +447,3 @@ def process_default(default):
         return False
     else:
         return default
-
-
-class ParserFieldPacked(object):
-    def __init__(self, pos, modifier, ftype, name, index):
-        self.token_type = 'FIELD'
-        self.pos = pos
-        self.modifier = modifier
-        self.type = ftype
-        self.name = name
-        self.index = int(index)
-        self.default = None
-        self.packed = True
-        self.deprecated = False
-
-
-class ParserFieldDeprecated(object):
-    def __init__(self, pos, modifier, ftype, name, index):
-        self.token_type = 'FIELD'
-        self.pos = pos
-        self.modifier = modifier
-        self.type = ftype
-        self.name = name
-        self.index = int(index)
-        self.default = None
-        self.packed = False
-        self.deprecated = True
-
-
-class ParserEnum(object):
-    def __init__(self, pos, name):
-        self.token_type = 'ENUM'
-        self.pos = pos
-        self.name = name
-        self.fields = []
-        # full_name may later be overriden with parent hierarchy when relevant
-        self.full_name = name
-
-
-class ParserEnumField(object):
-    def __init__(self, pos, name, value=None):
-        self.token_type = 'ENUM_FIELD'
-        self.pos = pos
-        self.name = name
-        if value is not None:
-            self.value = int(value, 0)
-        else:
-            self.value = None
-        # full_name may later be overriden with parent hierarchy when relevant
-        self.full_name = name
-
-
-class ParserLBrace(object):
-    def __init__(self, pos):
-        self.token_type = 'LBRACE'
-        self.pos = pos
-
-
-class ParserRBrace(object):
-    def __init__(self, pos):
-        self.token_type = 'RBRACE'
-        self.pos = pos
-

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -100,7 +100,6 @@ class Parser(object):
     def tokenize(self, s):
         pos = 0
         line = 1
-        _P = self.__class__
 
         m = self.get_token(s, pos)
         while m is not None:
@@ -109,37 +108,37 @@ class Parser(object):
             vals = subm.groups()
 
             if token_type == 'OPTION':
-                yield _P.ParserOption(pos, *vals)
+                yield self.ParserOption(pos, *vals)
 
             elif token_type == 'SYNTAX':
-                yield _P.ParserSyntax(pos, *vals)
+                yield self.ParserSyntax(pos, *vals)
 
             elif token_type == 'IMPORT':
-                yield _P.ParserImport(pos, *vals)
+                yield self.ParserImport(pos, *vals)
 
             elif token_type == 'MESSAGE':
-                yield _P.ParserMessage(pos, *vals)
+                yield self.ParserMessage(pos, *vals)
 
             elif token_type in ('FIELD', 'FIELD_WITH_DEFAULT'):
-                yield _P.ParserField(pos, *vals)
+                yield self.ParserField(pos, *vals)
 
             elif token_type == 'FIELD_PACKED':
-                yield _P.ParserFieldPacked(pos, *vals)
+                yield self.ParserFieldPacked(pos, *vals)
 
             elif token_type == 'FIELD_DEPRECATED':
-                yield _P.ParserFieldDeprecated(pos, *vals)
+                yield self.ParserFieldDeprecated(pos, *vals)
 
             elif token_type == 'ENUM':
-                yield _P.ParserEnum(pos, *vals)
+                yield self.ParserEnum(pos, *vals)
 
             elif token_type in ('ENUM_FIELD', 'ENUM_FIELD_WITH_VALUE'):
-                yield _P.ParserEnumField(pos, *vals)
+                yield self.ParserEnumField(pos, *vals)
 
             elif token_type == 'LBRACE':
-                yield _P.ParserLBrace(pos)
+                yield self.ParserLBrace(pos)
 
             elif token_type == 'RBRACE':
-                yield _P.ParserRBrace(pos)
+                yield self.ParserRBrace(pos)
 
             elif token_type == 'NEWLINE':
                 line += 1
@@ -331,13 +330,11 @@ class Parser(object):
         for submessage in message.messages.values():
             self.add_cython_info(submessage)
 
-
     class ParserOption(object):
         def __init__(self, pos, option):
             self.token_type = 'OPTION'
             self.pos = pos
             self.option = option
-
 
     class ParserSyntax(object):
         def __init__(self, pos, value):
@@ -345,13 +342,11 @@ class Parser(object):
             self.pos = pos
             self.value = value
 
-
     class ParserImport(object):
         def __init__(self, pos, value):
             self.token_type = 'IMPORT'
             self.pos = pos
             self.value = value
-
 
     class ParserMessage(object):
         def __init__(self, pos, name):
@@ -363,7 +358,6 @@ class Parser(object):
             self.messages = {}
             self.enums = {}
             self.fields = []
-
 
     class ParserField(object):
         def __init__(self, pos, modifier, ftype, name, index, default=None):
@@ -377,10 +371,6 @@ class Parser(object):
             self.packed = False
             self.deprecated = False
 
-
-
-
-
     class ParserFieldPacked(object):
         def __init__(self, pos, modifier, ftype, name, index):
             self.token_type = 'FIELD'
@@ -392,7 +382,6 @@ class Parser(object):
             self.default = None
             self.packed = True
             self.deprecated = False
-
 
     class ParserFieldDeprecated(object):
         def __init__(self, pos, modifier, ftype, name, index):
@@ -406,7 +395,6 @@ class Parser(object):
             self.packed = False
             self.deprecated = True
 
-
     class ParserEnum(object):
         def __init__(self, pos, name):
             self.token_type = 'ENUM'
@@ -415,7 +403,6 @@ class Parser(object):
             self.fields = []
             # full_name may later be overriden with parent hierarchy when relevant
             self.full_name = name
-
 
     class ParserEnumField(object):
         def __init__(self, pos, name, value=None):
@@ -429,12 +416,10 @@ class Parser(object):
             # full_name may later be overriden with parent hierarchy when relevant
             self.full_name = name
 
-
     class ParserLBrace(object):
         def __init__(self, pos):
             self.token_type = 'LBRACE'
             self.pos = pos
-
 
     class ParserRBrace(object):
         def __init__(self, pos):

--- a/pyrobuf/parse_proto3.py
+++ b/pyrobuf/parse_proto3.py
@@ -25,28 +25,28 @@ class Proto3Parser(Parser):
     }
 
 
-class ParserField(object):
-    def __init__(self, pos, modifier, ftype, name, index):
-        self.token_type = 'FIELD'
-        self.pos = pos
-        self.modifier = 'repeated' if modifier == 'repeated ' else 'optional'
-        self.type = ftype
-        self.name = name
-        self.index = int(index)
-        self.default = None
-        self.packed = ftype in Parser.scalars
-        self.deprecated = False
+    class ParserField(object):
+        def __init__(self, pos, modifier, ftype, name, index):
+            self.token_type = 'FIELD'
+            self.pos = pos
+            self.modifier = 'repeated' if modifier == 'repeated ' else 'optional'
+            self.type = ftype
+            self.name = name
+            self.index = int(index)
+            self.default = None
+            self.packed = ftype in Parser.scalars
+            self.deprecated = False
 
 
-class ParserFieldDeprecated(object):
-    def __init__(self, pos, modifier, ftype, name, index):
-        self.token_type = 'FIELD'
-        self.pos = pos
-        self.modifier = 'repeated' if modifier == 'repeated ' else 'optional'
-        self.type = ftype
-        self.name = name
-        self.index = int(index)
-        self.default = None
-        self.packed = ftype in Parser.scalars
-        self.deprecated = True
+    class ParserFieldDeprecated(object):
+        def __init__(self, pos, modifier, ftype, name, index):
+            self.token_type = 'FIELD'
+            self.pos = pos
+            self.modifier = 'repeated' if modifier == 'repeated ' else 'optional'
+            self.type = ftype
+            self.name = name
+            self.index = int(index)
+            self.default = None
+            self.packed = ftype in Parser.scalars
+            self.deprecated = True
 

--- a/pyrobuf/parse_proto3.py
+++ b/pyrobuf/parse_proto3.py
@@ -24,7 +24,6 @@ class Proto3Parser(Parser):
         'SYNTAX': Parser.tokens['SYNTAX']
     }
 
-
     class ParserField(object):
         def __init__(self, pos, modifier, ftype, name, index):
             self.token_type = 'FIELD'
@@ -37,7 +36,6 @@ class Proto3Parser(Parser):
             self.packed = ftype in Parser.scalars
             self.deprecated = False
 
-
     class ParserFieldDeprecated(object):
         def __init__(self, pos, modifier, ftype, name, index):
             self.token_type = 'FIELD'
@@ -49,4 +47,3 @@ class Proto3Parser(Parser):
             self.default = None
             self.packed = ftype in Parser.scalars
             self.deprecated = True
-


### PR DESCRIPTION
When `parse_proto3` is imported `ParseField` and `ParseFieldDeprecated` don't override the default (`parse_proto`) implementation causing to write wrong implementation for repeated fields: `field.modifier` will hold `'repeated '` value instead `'repeated'`.