### PR TITLE
use base64 encoding for bytes type when serializing/deserializing to/…

### DIFF
--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -5,6 +5,7 @@ from cpython.ref cimport PyObject
 from pyrobuf_list cimport *
 from pyrobuf_util cimport *
 
+import base64
 import json
 import warnings
 
@@ -885,7 +886,7 @@ cdef class {{ message.full_name }}:
         {%- elif field.type == 'message' %}
             self.{{ field.name }}.ParseFromDict(d["{{ field.name }}"])
         {%- elif field.type == 'bytes' %}
-            self.{{ field.name }} = d["{{ field.name }}"].encode('utf-8')
+            self.{{ field.name }} = base64.b64decode(d["{{ field.name }}"].encode('utf-8'))
         {%- else %}
             self.{{ field.name }} = d["{{ field.name }}"]
         {%- endif %}
@@ -931,7 +932,7 @@ cdef class {{ message.full_name }}:
             out["{{ field.name }}"] = {{ field.name }}_dict
         {%- elif field.type == 'bytes' %}
         if self._{{ field.name }}_isSet:
-            out["{{ field.name }}"] = self.{{ field.name }}.decode('utf-8')
+            out["{{ field.name }}"] = base64.b64encode(self.{{ field.name }}).decode('utf-8')
         {%- else %}
         if self._{{ field.name }}_isSet:
             out["{{ field.name }}"] = self.{{ field.name }}
@@ -962,7 +963,7 @@ cdef class {{ message.full_name }}:
             out["{{ field.name }}"] = {{ field.name }}_dict
         {%- elif field.type == 'bytes' %}
         if self._{{ field.name }}_isSet:
-            out["{{ field.name }}"] = self.{{ field.name }}.decode('utf-8')
+            out["{{ field.name }}"] = base64.b64encode(self.{{ field.name }}).decode('utf-8')
         {%- else %}
         if self._{{ field.name }}_isSet:
             out["{{ field.name }}"] = self.{{ field.name }}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import platform
 import sys
 
 
-VERSION = "0.8.2"
+VERSION = "0.8.3"
 HERE = os.path.dirname(os.path.abspath(__file__))
 PYROBUF_DEFS_PXI = "pyrobuf_defs.pxi"
 PYROBUF_LIST_PXD = "pyrobuf_list.pxd"

--- a/tests/test_message_field_types.py
+++ b/tests/test_message_field_types.py
@@ -1,5 +1,6 @@
 import unittest
 
+import base64
 import pytest
 from proto_lib_fixture import proto_lib
 
@@ -31,11 +32,11 @@ class MessageFieldTypesTest(unittest.TestCase):
     def test_bytes_payload_serialize_to_json(self):
         message = TestFieldTypes()
         message.payload = b'\x01\x02\x03'
-        self.assertEqual(message.SerializeToJson(), '{"payload": "\\u0001\\u0002\\u0003"}')
+        self.assertEqual(message.SerializeToJson(), '{"payload": "AQID"}')
 
     def test_bytes_payload_parse_from_json(self):
         message = TestFieldTypes()
-        message.ParseFromJson('{"payload": "\\u0001\\u0002\\u0003"}')
+        message.ParseFromJson('{"payload": "AQID"}')
         self.assertEqual(message.payload, b'\x01\x02\x03')
 
     def test_bytes_payload_with_default_has_default_value(self):


### PR DESCRIPTION
…from dict or json

Avoid errors because of invalid start bytes.