### PR TITLE
Comment parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/build/
 /.tox
 pyrobuf/src/pyrobuf_defs.pxi
 .pytest_cache
+.mypy_cache

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -474,6 +474,10 @@ class Parser(object):
         # setting previous as a place holder for the inner fields parsing
         previous = self.LBrace(-1)
         for token in tokens:
+            if self._handleComment(token,previous):
+                previous = token
+                continue
+
             if token.token_type == 'FIELD':
                 # fields will be added to the proper message by the following
                 # parser function that takes care of fields generally

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -195,11 +195,11 @@ class Parser(object):
                 self.string[pos], line + 1, self.lines[line]))
 
     def _handleComment(self, token, previous_token):
-        if token.token_type == 'MESSAGE' or token.token_type == 'ENUM' :
-            token.comment = self._lastComment              
+        if token.token_type == 'MESSAGE' or token.token_type == 'ENUM':
+            token.comment = self._lastComment
         self._lastComment = None
 
-        if token.token_type != "COMMENT_OL" and token.token_type != "COMMENT_ML":            
+        if token.token_type != "COMMENT_OL" and token.token_type != "COMMENT_ML":
             return False
 
         # use only regular comments, ignore normal, development comments
@@ -219,10 +219,10 @@ class Parser(object):
         messages = {}
         includes = includes or []
         scope = {}
-        previous = self.LBrace(-1)  
+        previous = self.LBrace(-1)
 
         for token in tokens:
-            if self._handleComment(token,previous):
+            if self._handleComment(token, previous):
                 continue
 
             if token.token_type == 'OPTION':
@@ -686,14 +686,13 @@ class Parser(object):
 
     class Comment_OL(Token):
         token_type = 'COMMENT_OL'
-        def __init__(self, line, comment):            
+        def __init__(self, line, comment):
             self.line = line
             self.comment = comment
 
     class Comment_ML(Token):
         token_type = 'COMMENT_ML'
         def __init__(self, line, comment):
-            
             self.line = line
             self.comment = comment
 
@@ -749,7 +748,7 @@ class Parser(object):
             self.modifier = None
             self.type = ftype
             self.name = name
-            # comment for attriute in class docstring
+            # comment for attribute in class docstring
             self.comment = None
             self.index = int(index)
             self.default = None
@@ -775,7 +774,7 @@ class Parser(object):
             if self.type == "message":
                 return prefix + self.message_name
             if self.type == "enum" :
-                return prefix + self.enum_name                
+                return prefix + self.enum_name
             return prefix + Parser.py_type_map[self.type]
 
     class MapField(Token):

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -567,18 +567,20 @@ class Parser(object):
         assert token.token_type == 'LBRACE', "missing opening brace on line {}: '{}'".format(
             token.line + 1, self.lines[token.line])
         previous = self.LBrace(-1) 
+        setDefault = False
 
-        for num, token in enumerate(tokens):
+        for token in tokens:
             if self._handleComment(token,previous):
                 previous = token
                 continue
 
             if token.token_type == 'ENUM_FIELD':
-                if num == 0:
+                if (setDefault is False):
                     if self.syntax == 3:
                         assert token.value == 0, "expected zero as first enum element on line {}, got {}: '{}'".format(
                             token.line + 1, token.value, self.lines[token.line])
                     current.default = token
+                    setDefault = True
 
                 token.full_name = "{}_{}".format(current.full_name, token.name)
 

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -16,37 +16,37 @@ from {{ import }}_proto cimport *
 
 
 {%- macro enum_fields_def(enum) %}
-class {{enum.full_name}}(enum.Enum):   
+class {{enum.full_name}}(enum.Enum):
     """
     {%- if enum.comment != None %}
-    {{enum.comment}} 
+    {{enum.comment}}
     {%- endif %}
     Enum Constants
-    --------------    
-    {%for field in enum.fields.values()|sort(attribute='name') %}        
+    --------------
+    {%for field in enum.fields.values()|sort(attribute='name') %}
     - `{{field.name}}` {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
     {%-endfor %}
-    """   
-    {%- for field in enum.fields.values() %}    
+    """
+    {%- for field in enum.fields.values() %}
     {{ field.name }} = _{{ field.full_name }} {%- if field.comment != None %} # {{field.comment}}{%- endif %}
     {%- endfor %}
 {%- endmacro %}
 
 
 {%- macro classdef(message) %}
-cdef class {{ message.full_name }}:   
+cdef class {{ message.full_name }}:
     """
-    {%- if message.comment != None %} 
-    {{message.comment}}    
+    {%- if message.comment != None %}
+    {{message.comment}}
     {%- endif %}
-    {%- if message.fields.values()|first is defined %} 
+    {%- if message.fields.values()|first is defined %}
     Attributes
     ----------
     {%- for field in message.fields.values() %}
     - `{{field.name}}`: {{field.get_python_type()}}{%- if field.modifier != 'required'%},optional{%- endif %} {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
     {%- endfor %}
     {%- endif %}
-    """    
+    """
     def __cinit__(self):
         self._listener = <PyObject *>null_listener
 
@@ -174,7 +174,7 @@ cdef class {{ message.full_name }}:
         return self._{{ field.name }}
 
     @{{ field.name }}.setter
-    def {{ field.name }}(self, value):        
+    def {{ field.name }}(self, value):
         {%- if field.deprecated|default(false) == true %}
         warnings.warn("field '{{ field.name }}' is deprecated", DeprecationWarning)
         {%- endif %}
@@ -1033,10 +1033,6 @@ cdef class {{ message.full_name }}:
         yield self.{{ field.name }}
     {%- endfor %}
 
-    {% for message_enum_name, message_enum in message.enums.items() %}
-        {{ enum_fields_def(message_enum) }}
-    {% endfor %}
-
     def Setters(self):
         """
         Iterator over functions to set the fields in a message.
@@ -1049,6 +1045,10 @@ cdef class {{ message.full_name }}:
             self.{{ field.name }} = value
         yield setter
     {%- endfor %}
+
+    {% for message_enum_name, message_enum in message.enums.items() %}
+{{ enum_fields_def(message_enum) }}
+    {% endfor %}
 
     {% for message_name, message_message in message.messages.items() %}
 {{ classdef(message_message) }}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -14,9 +14,21 @@ import enum
 from {{ import }}_proto cimport *
 {%- endfor %}
 
-{%- macro message_enum_fields_def(enum) %}
-    {%- for field in enum.fields.values() %}
-    {{ field.name }} = _{{ field.full_name }}
+
+{%- macro enum_fields_def(enum) %}
+class {{enum.full_name}}(enum.Enum):   
+    """
+    {%- if enum.comment != None %}
+    {{enum.comment}} 
+    {%- endif %}
+    Enum Constants
+    --------------    
+    {%for field in enum.fields.values()|sort(attribute='name') %}        
+    - `{{field.name}}` {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
+    {%-endfor %}
+    """   
+    {%- for field in enum.fields.values() %}    
+    {{ field.name }} = _{{ field.full_name }} {%- if field.comment != None %} # {{field.comment}}{%- endif %}
     {%- endfor %}
 {%- endmacro %}
 
@@ -1022,7 +1034,7 @@ cdef class {{ message.full_name }}:
     {%- endfor %}
 
     {% for message_enum_name, message_enum in message.enums.items() %}
-        {{ message_enum_fields_def(message_enum) }}
+        {{ enum_fields_def(message_enum) }}
     {% endfor %}
 
     def Setters(self):
@@ -1049,21 +1061,6 @@ class DecodeError(Exception):
 {%- for message in messages %}
 {{ classdef(message) }}
 {%- endfor %}
-
-{%- macro enum_fields_def(enum) %}
-class {{enum.name}}(enum.Enum):   
-    """
-    {%- if enum.comment != None %}
-    {{enum.comment}} 
-    {%- endif %}    
-    {%for field in enum.fields.values()|sort(attribute='name') %}        
-    - `{{field.name}}` {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
-    {%-endfor %}
-    """   
-    {%- for field in enum.fields.values() %}    
-    {{ field.name }} = _{{ field.full_name }} {%- if field.comment != None %} # {{field.comment}}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
 
 {%- for enum in enums %}
 {{ enum_fields_def(enum) }}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -8,6 +8,7 @@ from pyrobuf_util cimport *
 import base64
 import json
 import warnings
+import enum
 
 {%- for import in imports %}
 from {{ import }}_proto cimport *
@@ -21,8 +22,19 @@ from {{ import }}_proto cimport *
 
 
 {%- macro classdef(message) %}
-cdef class {{ message.full_name }}:
-
+cdef class {{ message.full_name }}:   
+    """
+    {%- if message.comment != None %} 
+    {{message.comment}}    
+    {%- endif %}
+    {%- if message.fields.values()|first is defined %} 
+    Attributes
+    ----------
+    {%- for field in message.fields.values() %}
+    - `{{field.name}}`: {{field.get_python_type()}}{%- if field.modifier != 'required'%},optional{%- endif %} {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
+    {%- endfor %}
+    {%- endif %}
+    """    
     def __cinit__(self):
         self._listener = <PyObject *>null_listener
 
@@ -134,6 +146,9 @@ cdef class {{ message.full_name }}:
     {% for index, field in message.fields|dictsort() %}
     @property
     def {{ field.name }}(self):
+        {%- if field.comment != None %}
+        """{{field.comment}}"""
+        {%- endif %}
         {%- if field.deprecated|default(false) == true %}
         warnings.warn("field '{{ field.name }}' is deprecated", DeprecationWarning)
         {%- endif %}
@@ -147,7 +162,7 @@ cdef class {{ message.full_name }}:
         return self._{{ field.name }}
 
     @{{ field.name }}.setter
-    def {{ field.name }}(self, value):
+    def {{ field.name }}(self, value):        
         {%- if field.deprecated|default(false) == true %}
         warnings.warn("field '{{ field.name }}' is deprecated", DeprecationWarning)
         {%- endif %}
@@ -1036,9 +1051,18 @@ class DecodeError(Exception):
 {%- endfor %}
 
 {%- macro enum_fields_def(enum) %}
-{%- for field in enum.fields.values() %}
-{{ field.name }} = _{{ field.full_name }}
-{%- endfor %}
+class {{enum.name}}(enum.Enum):   
+    """
+    {%- if enum.comment != None %}
+    {{enum.comment}} 
+    {%- endif %}    
+    {%for field in enum.fields.values()|sort(attribute='name') %}        
+    - `{{field.name}}` {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
+    {%-endfor %}
+    """   
+    {%- for field in enum.fields.values() %}    
+    {{ field.name }} = _{{ field.full_name }} {%- if field.comment != None %} # {{field.comment}}{%- endif %}
+    {%- endfor %}
 {%- endmacro %}
 
 {%- for enum in enums %}

--- a/tests/test_imported_enums.py
+++ b/tests/test_imported_enums.py
@@ -2,27 +2,27 @@ import unittest
 
 
 # These can't be imported until the test_imported_enums_proto module has been built.
-CLOSE = None
-MSG_ONE = None
-ExposesInternalEnumConstantsMessage = None
+Status = None
+MessageID = None
+ExposesInternalEnumConstantsMessageinternal_enum = None
 UsesImportedEnumsMessage = None
 
 
 class ImportedEnumsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        global CLOSE, MSG_ONE, ExposesInternalEnumConstantsMessage, UsesImportedEnumsMessage
-        from test_multi_messages_toplevel_enums_proto import MSG_ONE, CLOSE
-        from test_imported_enums_proto import UsesImportedEnumsMessage, ExposesInternalEnumConstantsMessage
+        global Status, MessageID, ExposesInternalEnumConstantsMessageinternal_enum, UsesImportedEnumsMessage
+        from test_multi_messages_toplevel_enums_proto import Status, MessageID
+        from test_imported_enums_proto import UsesImportedEnumsMessage, ExposesInternalEnumConstantsMessageinternal_enum
 
     def test_message_id_has_default_of_msg_one(self):
         message = UsesImportedEnumsMessage()
-        self.assertEqual(message.message_id, MSG_ONE)
+        self.assertEqual(message.message_id, MessageID.MSG_ONE.value)
 
     def test_status_has_default_of_close(self):
         message = UsesImportedEnumsMessage()
-        self.assertEqual(message.status, CLOSE)
+        self.assertEqual(message.status, Status.CLOSE.value)
 
     def test_internal_enum_constants_exposed(self):
-        self.assertEqual(ExposesInternalEnumConstantsMessage.INTERNAL, 0)
-        self.assertEqual(ExposesInternalEnumConstantsMessage.EXTERNAL, 1)
+        self.assertEqual(ExposesInternalEnumConstantsMessageinternal_enum.INTERNAL.value, 0)
+        self.assertEqual(ExposesInternalEnumConstantsMessageinternal_enum.EXTERNAL.value, 1)

--- a/tests/test_merge_from.py
+++ b/tests/test_merge_from.py
@@ -1,6 +1,7 @@
 import unittest
 
 Test = None
+TestEnumField = None
 TestSs1 = None
 TestSs3 = None
 
@@ -8,8 +9,8 @@ TestSs3 = None
 class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        global Test, TestSs1, TestSs3
-        from test_message_proto import Test, TestSs1, TestSs3
+        global Test, TestEnumField, TestSs1, TestSs3
+        from test_message_proto import Test, TestEnumField, TestSs1, TestSs3
 
     def test_merge_from_wrong_type_raises_type_error(self):
         dest = Test()
@@ -49,9 +50,9 @@ class MergeFromTest(unittest.TestCase):
     def test_merge_from_does_set_enum_field_that_is_set_in_source(self):
         source = Test()
         dest = Test()
-        source.enum_field = Test.TEST_ENUM_FIELD_2
+        source.enum_field = TestEnumField.TEST_ENUM_FIELD_2.value
         dest.MergeFrom(source)
-        self.assertEqual(dest.enum_field, Test.TEST_ENUM_FIELD_2)
+        self.assertEqual(dest.enum_field, TestEnumField.TEST_ENUM_FIELD_2.value)
 
     def test_merge_from_does_merge_message_field_that_is_set_in_source(self):
         source = TestSs3()


### PR DESCRIPTION
Add comment parsing #136 for message and enum definition. I only use the doxygen comments ( /**...*/,///) and skip normal developer comments (/*...*/,//) to filter IDE-Help. 
IDE-Help with docstring for python classes and getter function. 
To be able to show any help for enum definition in python, I had to define the **enums as a class**. 
Help to single Enum-Item is still open.