### PR TITLE
Base package pyrogen (for mypy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/build/
 /.tox
 pyrobuf/src/pyrobuf_defs.pxi
 .pytest_cache
+.mypy_cache

--- a/pyrobuf/compile.py
+++ b/pyrobuf/compile.py
@@ -24,7 +24,7 @@ class BasePackagePatch_BuildExt(build_ext):
     """
     def run(self):
         build_ext.run(self)
-        filename = Path(self.build_lib).joinpath(self.package).joinpath('__init__.py')
+        filename = Path(self.build_lib).joinpath('pyrogen').joinpath('__init__.py')
         filename.touch(exist_ok=True)
 
 class Compiler(object):
@@ -37,7 +37,7 @@ class Compiler(object):
                  proto3=False, force=False, package=None, includes=None,
                  clean=False):
         self.sources = sources
-        self.out = out
+        self.out = os.path.join(out, 'pyrogen')
         self.build = build
         self.install = install
         self.force = force
@@ -45,7 +45,7 @@ class Compiler(object):
         self.includes = includes or []
         self.clean = clean
         here = os.path.dirname(os.path.abspath(__file__))
-        self.include_path = [os.path.join(here, 'src'), self.out]
+        self.include_path = [os.path.join(here, 'src'), out]
         self._generated = set()
         self._messages = []
         self._pyx_files = []
@@ -103,10 +103,6 @@ class Compiler(object):
         setup(name='pyrobuf-generated',
                ext_modules=cythonize(self._pyx_files,
                                      include_path=self.include_path),
-               ext_package= 'pyrogen',
-               # This base package option is needed, to use mypy also as package: pyrogen-stubs
-               # I'm still unclear why __init__.py is not automatically generated. Maybe a bug?
-               # With this build_ext adaption it works. CT_02Jul19
                cmdclass= dict(build_ext=BasePackagePatch_BuildExt),
                script_args=script_args)
 
@@ -125,6 +121,8 @@ class Compiler(object):
     def _compile_spec(self):
         try:
             os.makedirs(self.out)
+            filename = Path(self.out).joinpath('__init__.py')
+            filename.touch(exist_ok=True)
         except _FileExistsError:
             pass
 

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -474,6 +474,10 @@ class Parser(object):
         # setting previous as a place holder for the inner fields parsing
         previous = self.LBrace(-1)
         for token in tokens:
+            if self._handleComment(token,previous):
+                previous = token
+                continue
+
             if token.token_type == 'FIELD':
                 # fields will be added to the proper message by the following
                 # parser function that takes care of fields generally

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -195,11 +195,11 @@ class Parser(object):
                 self.string[pos], line + 1, self.lines[line]))
 
     def _handleComment(self, token, previous_token):
-        if token.token_type == 'MESSAGE' or token.token_type == 'ENUM' :
-            token.comment = self._lastComment              
+        if token.token_type == 'MESSAGE' or token.token_type == 'ENUM':
+            token.comment = self._lastComment
         self._lastComment = None
 
-        if token.token_type != "COMMENT_OL" and token.token_type != "COMMENT_ML":            
+        if token.token_type != "COMMENT_OL" and token.token_type != "COMMENT_ML":
             return False
 
         # use only regular comments, ignore normal, development comments
@@ -219,10 +219,10 @@ class Parser(object):
         messages = {}
         includes = includes or []
         scope = {}
-        previous = self.LBrace(-1)  
+        previous = self.LBrace(-1)
 
         for token in tokens:
-            if self._handleComment(token,previous):
+            if self._handleComment(token, previous):
                 continue
 
             if token.token_type == 'OPTION':
@@ -686,14 +686,13 @@ class Parser(object):
 
     class Comment_OL(Token):
         token_type = 'COMMENT_OL'
-        def __init__(self, line, comment):            
+        def __init__(self, line, comment):
             self.line = line
             self.comment = comment
 
     class Comment_ML(Token):
         token_type = 'COMMENT_ML'
         def __init__(self, line, comment):
-            
             self.line = line
             self.comment = comment
 
@@ -749,7 +748,7 @@ class Parser(object):
             self.modifier = None
             self.type = ftype
             self.name = name
-            # comment for attriute in class docstring
+            # comment for attribute in class docstring
             self.comment = None
             self.index = int(index)
             self.default = None
@@ -775,7 +774,7 @@ class Parser(object):
             if self.type == "message":
                 return prefix + self.message_name
             if self.type == "enum" :
-                return prefix + self.enum_name                
+                return prefix + self.enum_name
             return prefix + Parser.py_type_map[self.type]
 
     class MapField(Token):

--- a/pyrobuf/parse_proto.py
+++ b/pyrobuf/parse_proto.py
@@ -567,18 +567,20 @@ class Parser(object):
         assert token.token_type == 'LBRACE', "missing opening brace on line {}: '{}'".format(
             token.line + 1, self.lines[token.line])
         previous = self.LBrace(-1) 
+        setDefault = False
 
-        for num, token in enumerate(tokens):
+        for token in tokens:
             if self._handleComment(token,previous):
                 previous = token
                 continue
 
             if token.token_type == 'ENUM_FIELD':
-                if num == 0:
+                if (setDefault is False):
                     if self.syntax == 3:
                         assert token.value == 0, "expected zero as first enum element on line {}, got {}: '{}'".format(
                             token.line + 1, token.value, self.lines[token.line])
                     current.default = token
+                    setDefault = True
 
                 token.full_name = "{}_{}".format(current.full_name, token.name)
 

--- a/pyrobuf/protobuf/templates/proto_pxd.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pxd.tmpl
@@ -8,7 +8,7 @@ from pyrobuf_util cimport *
 import json
 
 {%- for import in imports %}
-from {{ import }}_proto cimport *
+from pyrogen.{{ import }}_proto cimport *
 {%- endfor %}
 
 {%- macro classdef(message) %}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -16,37 +16,37 @@ from {{ import }}_proto cimport *
 
 
 {%- macro enum_fields_def(enum) %}
-class {{enum.full_name}}(enum.Enum):   
+class {{enum.full_name}}(enum.Enum):
     """
     {%- if enum.comment != None %}
-    {{enum.comment}} 
+    {{enum.comment}}
     {%- endif %}
     Enum Constants
-    --------------    
-    {%for field in enum.fields.values()|sort(attribute='name') %}        
+    --------------
+    {%for field in enum.fields.values()|sort(attribute='name') %}
     - `{{field.name}}` {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
     {%-endfor %}
-    """   
-    {%- for field in enum.fields.values() %}    
+    """
+    {%- for field in enum.fields.values() %}
     {{ field.name }} = _{{ field.full_name }} {%- if field.comment != None %} # {{field.comment}}{%- endif %}
     {%- endfor %}
 {%- endmacro %}
 
 
 {%- macro classdef(message) %}
-cdef class {{ message.full_name }}:   
+cdef class {{ message.full_name }}:
     """
-    {%- if message.comment != None %} 
-    {{message.comment}}    
+    {%- if message.comment != None %}
+    {{message.comment}}
     {%- endif %}
-    {%- if message.fields.values()|first is defined %} 
+    {%- if message.fields.values()|first is defined %}
     Attributes
     ----------
     {%- for field in message.fields.values() %}
     - `{{field.name}}`: {{field.get_python_type()}}{%- if field.modifier != 'required'%},optional{%- endif %} {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
     {%- endfor %}
     {%- endif %}
-    """    
+    """
     def __cinit__(self):
         self._listener = <PyObject *>null_listener
 
@@ -174,7 +174,7 @@ cdef class {{ message.full_name }}:
         return self._{{ field.name }}
 
     @{{ field.name }}.setter
-    def {{ field.name }}(self, value):        
+    def {{ field.name }}(self, value):
         {%- if field.deprecated|default(false) == true %}
         warnings.warn("field '{{ field.name }}' is deprecated", DeprecationWarning)
         {%- endif %}
@@ -1033,10 +1033,6 @@ cdef class {{ message.full_name }}:
         yield self.{{ field.name }}
     {%- endfor %}
 
-    {% for message_enum_name, message_enum in message.enums.items() %}
-        {{ enum_fields_def(message_enum) }}
-    {% endfor %}
-
     def Setters(self):
         """
         Iterator over functions to set the fields in a message.
@@ -1049,6 +1045,10 @@ cdef class {{ message.full_name }}:
             self.{{ field.name }} = value
         yield setter
     {%- endfor %}
+
+    {% for message_enum_name, message_enum in message.enums.items() %}
+{{ enum_fields_def(message_enum) }}
+    {% endfor %}
 
     {% for message_name, message_message in message.messages.items() %}
 {{ classdef(message_message) }}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -11,7 +11,7 @@ import warnings
 import enum
 
 {%- for import in imports %}
-from {{ import }}_proto cimport *
+from pyrogen.{{ import }}_proto cimport *
 {%- endfor %}
 
 

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -14,9 +14,21 @@ import enum
 from {{ import }}_proto cimport *
 {%- endfor %}
 
-{%- macro message_enum_fields_def(enum) %}
-    {%- for field in enum.fields.values() %}
-    {{ field.name }} = _{{ field.full_name }}
+
+{%- macro enum_fields_def(enum) %}
+class {{enum.full_name}}(enum.Enum):   
+    """
+    {%- if enum.comment != None %}
+    {{enum.comment}} 
+    {%- endif %}
+    Enum Constants
+    --------------    
+    {%for field in enum.fields.values()|sort(attribute='name') %}        
+    - `{{field.name}}` {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
+    {%-endfor %}
+    """   
+    {%- for field in enum.fields.values() %}    
+    {{ field.name }} = _{{ field.full_name }} {%- if field.comment != None %} # {{field.comment}}{%- endif %}
     {%- endfor %}
 {%- endmacro %}
 
@@ -1022,7 +1034,7 @@ cdef class {{ message.full_name }}:
     {%- endfor %}
 
     {% for message_enum_name, message_enum in message.enums.items() %}
-        {{ message_enum_fields_def(message_enum) }}
+        {{ enum_fields_def(message_enum) }}
     {% endfor %}
 
     def Setters(self):
@@ -1049,21 +1061,6 @@ class DecodeError(Exception):
 {%- for message in messages %}
 {{ classdef(message) }}
 {%- endfor %}
-
-{%- macro enum_fields_def(enum) %}
-class {{enum.name}}(enum.Enum):   
-    """
-    {%- if enum.comment != None %}
-    {{enum.comment}} 
-    {%- endif %}    
-    {%for field in enum.fields.values()|sort(attribute='name') %}        
-    - `{{field.name}}` {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
-    {%-endfor %}
-    """   
-    {%- for field in enum.fields.values() %}    
-    {{ field.name }} = _{{ field.full_name }} {%- if field.comment != None %} # {{field.comment}}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
 
 {%- for enum in enums %}
 {{ enum_fields_def(enum) }}

--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -8,6 +8,7 @@ from pyrobuf_util cimport *
 import base64
 import json
 import warnings
+import enum
 
 {%- for import in imports %}
 from {{ import }}_proto cimport *
@@ -21,8 +22,19 @@ from {{ import }}_proto cimport *
 
 
 {%- macro classdef(message) %}
-cdef class {{ message.full_name }}:
-
+cdef class {{ message.full_name }}:   
+    """
+    {%- if message.comment != None %} 
+    {{message.comment}}    
+    {%- endif %}
+    {%- if message.fields.values()|first is defined %} 
+    Attributes
+    ----------
+    {%- for field in message.fields.values() %}
+    - `{{field.name}}`: {{field.get_python_type()}}{%- if field.modifier != 'required'%},optional{%- endif %} {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
+    {%- endfor %}
+    {%- endif %}
+    """    
     def __cinit__(self):
         self._listener = <PyObject *>null_listener
 
@@ -134,6 +146,9 @@ cdef class {{ message.full_name }}:
     {% for index, field in message.fields|dictsort() %}
     @property
     def {{ field.name }}(self):
+        {%- if field.comment != None %}
+        """{{field.comment}}"""
+        {%- endif %}
         {%- if field.deprecated|default(false) == true %}
         warnings.warn("field '{{ field.name }}' is deprecated", DeprecationWarning)
         {%- endif %}
@@ -147,7 +162,7 @@ cdef class {{ message.full_name }}:
         return self._{{ field.name }}
 
     @{{ field.name }}.setter
-    def {{ field.name }}(self, value):
+    def {{ field.name }}(self, value):        
         {%- if field.deprecated|default(false) == true %}
         warnings.warn("field '{{ field.name }}' is deprecated", DeprecationWarning)
         {%- endif %}
@@ -1036,9 +1051,18 @@ class DecodeError(Exception):
 {%- endfor %}
 
 {%- macro enum_fields_def(enum) %}
-{%- for field in enum.fields.values() %}
-{{ field.name }} = _{{ field.full_name }}
-{%- endfor %}
+class {{enum.name}}(enum.Enum):   
+    """
+    {%- if enum.comment != None %}
+    {{enum.comment}} 
+    {%- endif %}    
+    {%for field in enum.fields.values()|sort(attribute='name') %}        
+    - `{{field.name}}` {% if field.comment != None %} \&ndash; {{field.comment}} {%- endif %}
+    {%-endfor %}
+    """   
+    {%- for field in enum.fields.values() %}    
+    {{ field.name }} = _{{ field.full_name }} {%- if field.comment != None %} # {{field.comment}}{%- endif %}
+    {%- endfor %}
 {%- endmacro %}
 
 {%- for enum in enums %}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import platform
 import sys
 
 
-VERSION = "0.9.0"
+VERSION = "0.9.0.vistec"
 HERE = os.path.dirname(os.path.abspath(__file__))
 PYROBUF_DEFS_PXI = "pyrobuf_defs.pxi"
 PYROBUF_LIST_PXD = "pyrobuf_list.pxd"

--- a/tests/create_message.py
+++ b/tests/create_message.py
@@ -7,7 +7,7 @@ if sys.version_info.major == 2:
 
 def create_an_test():
     # print LIB
-    import test_message_proto as an_test
+    import pyrogen.test_message_proto as an_test
     test = an_test.Test()
     test.timestamp = 539395200
     test.field = 10689

--- a/tests/test_custom_options.py
+++ b/tests/test_custom_options.py
@@ -8,7 +8,7 @@ class TestCustomOptionsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global TestCustomOptions
-        from test_custom_options_proto import TestCustomOptions
+        from pyrogen.test_custom_options_proto import TestCustomOptions
 
     def test_fields(self):
         test = TestCustomOptions()

--- a/tests/test_deprecated_field.py
+++ b/tests/test_deprecated_field.py
@@ -4,7 +4,7 @@ import warnings
 
 class DecimalDefaultsTest(unittest.TestCase):
     def setUp(self):
-        from test_message_field_types_proto import TestDeprecatedField
+        from pyrogen.test_message_field_types_proto import TestDeprecatedField
         warnings.filterwarnings("error")
         self.message = TestDeprecatedField()
 

--- a/tests/test_field_defaults.py
+++ b/tests/test_field_defaults.py
@@ -9,7 +9,7 @@ class DecimalDefaultsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global TestDecimalDefaultsMessage
-        from test_field_defaults_proto import TestDecimalDefaultsMessage
+        from pyrogen.test_field_defaults_proto import TestDecimalDefaultsMessage
 
     def setUp(self):
         self.message = TestDecimalDefaultsMessage()
@@ -61,7 +61,7 @@ class StringDefaultsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global TestStringDefaultsMessage
-        from test_field_defaults_proto import TestStringDefaultsMessage
+        from pyrogen.test_field_defaults_proto import TestStringDefaultsMessage
 
     def setUp(self):
         self.message = TestStringDefaultsMessage()

--- a/tests/test_has_field.py
+++ b/tests/test_has_field.py
@@ -11,8 +11,8 @@ class HasFieldTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global Test, TestRef, TestSs1, TestSs1Thing
-        from test_message_proto import Test, TestSs1, TestSs1Thing
-        from test_ref_message_proto import TestRef
+        from pyrogen.test_ref_message_proto import TestRef
+        from pyrogen.test_message_proto import Test, TestSs1, TestSs1Thing
 
     def test_has_field_for_repeated_field_raises_value_error(self):
         message = Test()

--- a/tests/test_has_field_many.py
+++ b/tests/test_has_field_many.py
@@ -1,5 +1,5 @@
 def test_has_field():
-    from test_many_fields_proto import TestManyFields
+    from pyrogen.test_many_fields_proto import TestManyFields
     test = TestManyFields()
 
     # Assert HasField false on clean message

--- a/tests/test_imported_enums.py
+++ b/tests/test_imported_enums.py
@@ -2,27 +2,27 @@ import unittest
 
 
 # These can't be imported until the test_imported_enums_proto module has been built.
-CLOSE = None
-MSG_ONE = None
-ExposesInternalEnumConstantsMessage = None
+Status = None
+MessageID = None
+ExposesInternalEnumConstantsMessageinternal_enum = None
 UsesImportedEnumsMessage = None
 
 
 class ImportedEnumsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        global CLOSE, MSG_ONE, ExposesInternalEnumConstantsMessage, UsesImportedEnumsMessage
-        from test_multi_messages_toplevel_enums_proto import MSG_ONE, CLOSE
-        from test_imported_enums_proto import UsesImportedEnumsMessage, ExposesInternalEnumConstantsMessage
+        global Status, MessageID, ExposesInternalEnumConstantsMessageinternal_enum, UsesImportedEnumsMessage
+        from test_multi_messages_toplevel_enums_proto import Status, MessageID
+        from test_imported_enums_proto import UsesImportedEnumsMessage, ExposesInternalEnumConstantsMessageinternal_enum
 
     def test_message_id_has_default_of_msg_one(self):
         message = UsesImportedEnumsMessage()
-        self.assertEqual(message.message_id, MSG_ONE)
+        self.assertEqual(message.message_id, MessageID.MSG_ONE.value)
 
     def test_status_has_default_of_close(self):
         message = UsesImportedEnumsMessage()
-        self.assertEqual(message.status, CLOSE)
+        self.assertEqual(message.status, Status.CLOSE.value)
 
     def test_internal_enum_constants_exposed(self):
-        self.assertEqual(ExposesInternalEnumConstantsMessage.INTERNAL, 0)
-        self.assertEqual(ExposesInternalEnumConstantsMessage.EXTERNAL, 1)
+        self.assertEqual(ExposesInternalEnumConstantsMessageinternal_enum.INTERNAL.value, 0)
+        self.assertEqual(ExposesInternalEnumConstantsMessageinternal_enum.EXTERNAL.value, 1)

--- a/tests/test_imported_enums.py
+++ b/tests/test_imported_enums.py
@@ -12,8 +12,8 @@ class ImportedEnumsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global Status, MessageID, ExposesInternalEnumConstantsMessageinternal_enum, UsesImportedEnumsMessage
-        from test_multi_messages_toplevel_enums_proto import Status, MessageID
-        from test_imported_enums_proto import UsesImportedEnumsMessage, ExposesInternalEnumConstantsMessageinternal_enum
+        from pyrogen.test_multi_messages_toplevel_enums_proto import Status, MessageID
+        from pyrogen.test_imported_enums_proto import UsesImportedEnumsMessage, ExposesInternalEnumConstantsMessageinternal_enum
 
     def test_message_id_has_default_of_msg_one(self):
         message = UsesImportedEnumsMessage()

--- a/tests/test_is_initialized.py
+++ b/tests/test_is_initialized.py
@@ -10,7 +10,7 @@ class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global TestIsInitialized, SubMessage, TestWithRequiredSubMessage
-        from test_is_initialized_proto import TestIsInitialized, SubMessage, TestWithRequiredSubMessage
+        from pyrogen.test_is_initialized_proto import TestIsInitialized, SubMessage, TestWithRequiredSubMessage
 
     def test_new_message_is_not_initialized(self):
         message = TestIsInitialized()

--- a/tests/test_issue_11.py
+++ b/tests/test_issue_11.py
@@ -1,12 +1,12 @@
 def test_before_overflow():
-    from issue_11_proto import A
+    from pyrogen.issue_11_proto import A
     a = A()
     a.a0 = 0x7FFFFFFF
     assert A.FromString(a.SerializeToString()).a0 == 2147483647
 
 
 def test_after_overflow():
-    from issue_11_proto import A
+    from pyrogen.issue_11_proto import A
     a = A()
     a.a0 = 0x80000000
     assert A.FromString(a.SerializeToString()).a0 == 2147483648

--- a/tests/test_issue_69.py
+++ b/tests/test_issue_69.py
@@ -1,10 +1,10 @@
 def test_message_a():
-    from issue_69_proto import A, B
+    from pyrogen.issue_69_proto import A, B
     a = A()
     assert type(a.b.a.b) == B
 
 
 def test_message_b():
-    from issue_69_proto import A, B
+    from pyrogen.issue_69_proto import A, B
     b = B()
     assert type(b.a.b.a) == A

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -8,7 +8,7 @@ class ItemsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global Test
-        from test_message_proto import Test
+        from pyrogen.test_message_proto import Test
 
     def test_fields(self):
         test = create_an_test()

--- a/tests/test_merge_from.py
+++ b/tests/test_merge_from.py
@@ -10,7 +10,7 @@ class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global Test, TestEnumField, TestSs1, TestSs3
-        from test_message_proto import Test, TestEnumField, TestSs1, TestSs3
+        from pyrogen.test_message_proto import Test, TestEnumField, TestSs1, TestSs3
 
     def test_merge_from_wrong_type_raises_type_error(self):
         dest = Test()

--- a/tests/test_merge_from.py
+++ b/tests/test_merge_from.py
@@ -1,6 +1,7 @@
 import unittest
 
 Test = None
+TestEnumField = None
 TestSs1 = None
 TestSs3 = None
 
@@ -8,8 +9,8 @@ TestSs3 = None
 class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        global Test, TestSs1, TestSs3
-        from test_message_proto import Test, TestSs1, TestSs3
+        global Test, TestEnumField, TestSs1, TestSs3
+        from test_message_proto import Test, TestEnumField, TestSs1, TestSs3
 
     def test_merge_from_wrong_type_raises_type_error(self):
         dest = Test()
@@ -49,9 +50,9 @@ class MergeFromTest(unittest.TestCase):
     def test_merge_from_does_set_enum_field_that_is_set_in_source(self):
         source = Test()
         dest = Test()
-        source.enum_field = Test.TEST_ENUM_FIELD_2
+        source.enum_field = TestEnumField.TEST_ENUM_FIELD_2.value
         dest.MergeFrom(source)
-        self.assertEqual(dest.enum_field, Test.TEST_ENUM_FIELD_2)
+        self.assertEqual(dest.enum_field, TestEnumField.TEST_ENUM_FIELD_2.value)
 
     def test_merge_from_does_merge_message_field_that_is_set_in_source(self):
         source = TestSs3()

--- a/tests/test_message_field_types.py
+++ b/tests/test_message_field_types.py
@@ -7,7 +7,7 @@ class MessageFieldTypesTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global TestFieldTypes
-        from test_message_field_types_proto import TestFieldTypes
+        from pyrogen.test_message_field_types_proto import TestFieldTypes
 
     def test_bytes_payload_serialize_to_string(self):
         message = TestFieldTypes()

--- a/tests/test_message_init_kwargs.py
+++ b/tests/test_message_init_kwargs.py
@@ -9,7 +9,7 @@ class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global Test, TestSs1, TestSs3
-        from test_message_proto import Test, TestSs1, TestSs3
+        from pyrogen.test_message_proto import Test, TestSs1, TestSs3
 
     def test_message_init_with_bad_keyword_arg_raises_value_error(self):
         self.assertRaises(ValueError, Test, non_existant=3)

--- a/tests/test_message_with_no_fields.py
+++ b/tests/test_message_with_no_fields.py
@@ -7,7 +7,7 @@ class EmptyMessageTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global EmptyMessageWithNoFields
-        from test_message_field_types_proto import EmptyMessageWithNoFields
+        from pyrogen.test_message_field_types_proto import EmptyMessageWithNoFields
 
     def setUp(self):
         self.message = EmptyMessageWithNoFields()

--- a/tests/test_nested_issue55.py
+++ b/tests/test_nested_issue55.py
@@ -16,7 +16,7 @@ class NestedTest(unittest.TestCase):
         global M
         global MN
         global MN2
-        from test_nested_issue55_proto import M, MN, MN2
+        from pyrogen.test_nested_issue55_proto import M, MN, MN2
 
     def test_use_nested(self):
         """

--- a/tests/test_repeated_enum.py
+++ b/tests/test_repeated_enum.py
@@ -8,7 +8,7 @@ class RepeatedEnumTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global TestRepeatedEnum
-        from test_repeated_enum_proto import TestRepeatedEnum
+        from pyrogen.test_repeated_enum_proto import TestRepeatedEnum
 
     def test_repeated_enum_serde(self):
         message1 = TestRepeatedEnum()

--- a/tests/test_signed_integer.py
+++ b/tests/test_signed_integer.py
@@ -18,7 +18,7 @@ def gen_rand_uint64():
 
 
 def test_int32():
-    from test_signed_integer_proto import Int
+    from pyrogen.test_signed_integer_proto import Int
     a = Int()
     v = gen_rand_int32()
     a.Int32 = v
@@ -26,7 +26,7 @@ def test_int32():
 
 
 def test_int64():
-    from test_signed_integer_proto import Int
+    from pyrogen.test_signed_integer_proto import Int
     a = Int()
     v = gen_rand_int64()
     a.Int64 = v
@@ -34,7 +34,7 @@ def test_int64():
 
 
 def test_uint32():
-    from test_signed_integer_proto import Int
+    from pyrogen.test_signed_integer_proto import Int
     a = Int()
     v = gen_rand_uint32()
     a.UInt32 = v
@@ -42,7 +42,7 @@ def test_uint32():
 
 
 def test_uint64():
-    from test_signed_integer_proto import Int
+    from pyrogen.test_signed_integer_proto import Int
     a = Int()
     v = gen_rand_uint64()
     a.UInt64 = v
@@ -50,7 +50,7 @@ def test_uint64():
 
 
 def test_sint32():
-    from test_signed_integer_proto import Int
+    from pyrogen.test_signed_integer_proto import Int
     a = Int()
     v = gen_rand_int32()
     a.SInt32 = v
@@ -58,7 +58,7 @@ def test_sint32():
 
 
 def test_sint64():
-    from test_signed_integer_proto import Int
+    from pyrogen.test_signed_integer_proto import Int
     a = Int()
     v = gen_rand_int64()
     a.SInt64 = v

--- a/tests/test_typed_lists.py
+++ b/tests/test_typed_lists.py
@@ -8,8 +8,8 @@ class MergeFromTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global Test, TestRef
-        from test_message_proto import Test
-        from test_ref_message_proto import TestRef
+        from pyrogen.test_ref_message_proto import TestRef
+        from pyrogen.test_message_proto import Test
 
     def test_extend_with_generic_list(self):
         t = Test()

--- a/tests/test_unicode_strings.py
+++ b/tests/test_unicode_strings.py
@@ -11,7 +11,7 @@ class TestUnicodeStrings(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global Test, TestSs1, TestFieldTypes
-        from test_message_proto import Test, TestSs1
+        from pyrogen.test_message_proto import Test, TestSs1
 
     def test_unicode_string_parse_from_string(self):
         message = Test.FromString(b'\x1a\x08\xce\x91\xce\x92\xce\x93\xce\x94')

--- a/tests/test_unknown_field.py
+++ b/tests/test_unknown_field.py
@@ -15,7 +15,7 @@ class MessageTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global TestTruncated
-        from test_truncated_proto import TestTruncated
+        from pyrogen.test_truncated_proto import TestTruncated
 
     def test_deser(self):
         test = TestTruncated()


### PR DESCRIPTION
The cythonize package option, used in _Better packaging_ #114, loses Proto-File namespace. 100 messages and more in one big file is not practical. 👎   To hold file structure helped. A base package over all generated pyrobuf message, would be great. I think that's equal to package scope #107 ?

### [MYPY support](https://mypy.readthedocs.io/en/latest/stubs.html)
On the other side a base package scope is needed to support static type checking, the other big advantage of cython generated code compared to google #136. All you need is to install a [stub-only package](https://www.python.org/dev/peps/pep-0561/) `pyrogen-stubs`  to check  pyrobuf generated code in package `pyrogen` 