### PR TITLE
Fixed generated egg name not respecting package name parameter

### DIFF
--- a/pyrobuf/compile.py
+++ b/pyrobuf/compile.py
@@ -90,7 +90,7 @@ class Compiler(object):
         if self.package is not None:
             self._package()
 
-        setup(name='pyrobuf-generated',
+        setup(name='pyrobuf-generated' if not self.package else self.package,
               ext_modules=cythonize(self._pyx_files,
                                     include_path=self.include_path),
               script_args=script_args)


### PR DESCRIPTION
Fixed egg name not respecting a package name specified with the --package parameter and always defaulting to pyrobuf_generated.

Before this fix, a generated egg with: pyrobuf --install --package=mytest mytest.proto would yield an egg named "pyrobuf_generated.egg" instead of "mytest.egg"