### PR TITLE
Fix broken setuptools_ext

### DIFF
--- a/pyrobuf/setuptools_ext.py
+++ b/pyrobuf/setuptools_ext.py
@@ -1,17 +1,24 @@
 """Setuptools integration."""
+import os
+import sys
+
 from pyrobuf.compile import Compiler
 
-try:
-    basestring
-except NameError:
-    # Python 3.x
+if sys.version_info.major == 3:
     basestring = str
+    _FileExistsError = FileExistsError
+else:
+    _FileExistsError = OSError
 
 
 def add_pyrobuf_module(dist, pyrobuf_module):
     dir_name = "pyrobuf/_" + pyrobuf_module
-    compiler = Compiler(pyrobuf_module, out=dir_name,
-                        package="{}_{}".format(dist.get_name(), pyrobuf_module))
+    package = "{}_{}".format(dist.get_name(), pyrobuf_module)
+    try:
+        os.makedirs(os.path.join(dir_name, package))
+    except _FileExistsError:
+        pass
+    compiler = Compiler([pyrobuf_module], out=dir_name, package=package)
     compiler.extend(dist)
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import platform
 import sys
 
 
-VERSION = "0.9.0"
+VERSION = "0.9.1"
 HERE = os.path.dirname(os.path.abspath(__file__))
 PYROBUF_DEFS_PXI = "pyrobuf_defs.pxi"
 PYROBUF_LIST_PXD = "pyrobuf_list.pxd"


### PR DESCRIPTION
Current implementation fails both on Python 2.7 and Python 3.x

```
$ cat setup.py 
from setuptools import setup, find_packages

setup(
    name="sample",
    version="0.1",
    packages=find_packages(),
    description="A sample package",
    install_requires=['pyrobuf'],
    setup_requires=['pyrobuf'],
    pyrobuf_modules="proto"
)

$ python setup.py install
generating p
Traceback (most recent call last):
  File "setup.py", line 10, in <module>
    pyrobuf_modules="proto"
  File "/home/lauris/v4/sample/venv/lib/python3.7/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.7/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/home/lauris/v4/sample/venv/lib/python3.7/site-packages/setuptools/dist.py", line 448, in __init__
    k: v for k, v in attrs.items()
  File "/usr/lib/python3.7/distutils/dist.py", line 292, in __init__
    self.finalize_options()
  File "/home/lauris/v4/sample/venv/lib/python3.7/site-packages/setuptools/dist.py", line 740, in finalize_options
    ep.load()(self)
  File "/home/lauris/v4/sample/venv/lib/python3.7/site-packages/setuptools/dist.py", line 747, in _finalize_setup_keywords
    ep.load()(self, ep.name, value)
  File "/home/lauris/v4/sample/.eggs/pyrobuf-0.9.0-py3.7-linux-x86_64.egg/pyrobuf/setuptools_ext.py", line 25, in pyrobuf_modules
    add_pyrobuf_module(dist, pyrobuf_module)
  File "/home/lauris/v4/sample/.eggs/pyrobuf-0.9.0-py3.7-linux-x86_64.egg/pyrobuf/setuptools_ext.py", line 15, in add_pyrobuf_module
    compiler.extend(dist)
  File "/home/lauris/v4/sample/.eggs/pyrobuf-0.9.0-py3.7-linux-x86_64.egg/pyrobuf/compile.py", line 99, in extend
    self._compile_spec()
  File "/home/lauris/v4/sample/.eggs/pyrobuf-0.9.0-py3.7-linux-x86_64.egg/pyrobuf/compile.py", line 121, in _compile_spec
    self._generate(source)
  File "/home/lauris/v4/sample/.eggs/pyrobuf-0.9.0-py3.7-linux-x86_64.egg/pyrobuf/compile.py", line 133, in _generate
    msg_def = self.parser.parse_from_filename(filename, self.includes)
  File "/home/lauris/v4/sample/.eggs/pyrobuf-0.9.0-py3.7-linux-x86_64.egg/pyrobuf/parse_proto.py", line 255, in parse_from_filename
    with open(fname, 'r') as fp:
FileNotFoundError: [Errno 2] No such file or directory: 'p'```


