### PR TITLE
Return bool fields as bool, not int

### DIFF
--- a/pyrobuf/protobuf/templates/proto_pyx.tmpl
+++ b/pyrobuf/protobuf/templates/proto_pyx.tmpl
@@ -144,7 +144,11 @@ cdef class {{ message.full_name }}:
             self._{{ field.name }}.reset()
             self._{{ field.name }}._listener = <PyObject *>self
         {%- endif %}
+        {%- if field.type == "bool" %}
+        return bool(self._{{ field.name }})
+        {%- else %}
         return self._{{ field.name }}
+        {%- endif %}
 
     @{{ field.name }}.setter
     def {{ field.name }}(self, value):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import platform
 import sys
 
 
-VERSION = "0.9.1"
+VERSION = "0.9.2"
 HERE = os.path.dirname(os.path.abspath(__file__))
 PYROBUF_DEFS_PXI = "pyrobuf_defs.pxi"
 PYROBUF_LIST_PXD = "pyrobuf_list.pxd"

--- a/tests/proto/test_ref_message.proto
+++ b/tests/proto/test_ref_message.proto
@@ -3,4 +3,5 @@ message TestRef {
 	optional int64 field1 = 2;
 	optional double field2 = 3;
 	optional string field3 = 4;
+	optional bool field4 = 5;
 }

--- a/tests/test_float_field.py
+++ b/tests/test_float_field.py
@@ -1,0 +1,17 @@
+import unittest
+
+TestRef = None
+
+
+class BoolFieldTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        global TestRef
+        from test_ref_message_proto import TestRef
+
+    def test_bool_field(self):
+        message = TestRef()
+        self.assertIsInstance(message.field4, bool)
+        self.assertIs(message.field4, False)
+        message.field4 = True
+        self.assertIs(message.field4, True)


### PR DESCRIPTION
Current implementation returns `bool` fields as `int`.

Protobuf specification implies it should be `bool` - https://developers.google.com/protocol-buffers/docs/proto3#json