### PR TITLE
Pin jinja2 version to 2.11.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
     url='https://github.com/appnexus/pyrobuf',
     author='AppNexus',
     tests_require=['pytest'] + (['protobuf >= 2.6.0, <3'] if sys.version_info.major == 2 else []),
-    setup_requires=['jinja2 >= 2.8', 'cython >= 0.23', 'pytest-runner'],
-    install_requires=['jinja2 >= 2.8', 'cython >= 0.23'],
+    setup_requires=['jinja2 == 2.11.3', 'cython >= 0.23', 'pytest-runner'],
+    install_requires=['jinja2 == 2.11.3', 'cython >= 0.23'],
     zip_safe=False,
 )


### PR DESCRIPTION
Jinja2 v3.0 bumps its MarkupSafe dependency to a release candidate. This breaks resolution of the package on ARM-based machines. Since the changes in jinja 3.0 don't seem to affect the functionality of this project, we propose pinning the jinja version to 2.11.3 until its MarkupSafe dependency is bumped to a major version, instead of a release candidate.